### PR TITLE
ensure wait for assets

### DIFF
--- a/deploy/artifacts/release.ts
+++ b/deploy/artifacts/release.ts
@@ -32,7 +32,7 @@ async function main() {
 
 	const ab = await Promise.all(
 		mappings.map(async ([name, file]) =>
-			Github.rest.repos.uploadReleaseAsset({
+			await Github.rest.repos.uploadReleaseAsset({
 				owner: context.repo.owner,
 				repo: context.repo.repo,
 				release_id: (await release).data.id,


### PR DESCRIPTION
- Releases are named for commit hash; actually include build artifacts (#112)
- Use SHA for release artifacts (#113)
- create synthetic tag name for releases (#115)
- try to use bazel node_modules for builds (#114)
- fix releases (#116)
- try to make bazelisk work again (#117)
- rootpath (#118)
- Mime (#119)
- use await to ensure we wait for asset upload
