### PR TITLE
fix upload issue due to https://github.com/octokit/octokit.js/discussions/2087#discussioncomment-646569

### DIFF
--- a/deploy/artifacts/release.ts
+++ b/deploy/artifacts/release.ts
@@ -32,7 +32,7 @@ async function main() {
 
 	const ab = await Promise.all(
 		mappings.map(async ([name, file]) =>
-			Github.rest.repos.uploadReleaseAsset({
+			await Github.rest.repos.uploadReleaseAsset({
 				owner: context.repo.owner,
 				repo: context.repo.repo,
 				release_id: (await release).data.id,

--- a/deploy/artifacts/release.ts
+++ b/deploy/artifacts/release.ts
@@ -37,7 +37,8 @@ async function main() {
 				repo: context.repo.repo,
 				release_id: (await release).data.id,
 				name,
-				data: (await fs.readFile(file)).toString('utf-8'),
+				// https://github.com/octokit/octokit.js/discussions/2087#discussioncomment-646569
+				data: (await fs.readFile(file)) as unknown as string,
 			})
 		)
 	);


### PR DESCRIPTION
- Releases are named for commit hash; actually include build artifacts (#112)
- Use SHA for release artifacts (#113)
- create synthetic tag name for releases (#115)
- try to use bazel node_modules for builds (#114)
- fix releases (#116)
- try to make bazelisk work again (#117)
- rootpath (#118)
- Mime (#119)
- use await to ensure we wait for asset upload
- fix upload issue due to https://github.com/octokit/octokit.js/discussions/2087\#discussioncomment-646569
