### PR TITLE
fix

### DIFF
--- a/deploy/artifacts/BUILD
+++ b/deploy/artifacts/BUILD
@@ -12,9 +12,9 @@ ts_project(
     name = "release_src",
     srcs = ["release.ts"],
     deps = [
-        "@npm//mime",
         "@npm//@actions/github",
         "@npm//@types/node",
+        "@npm//mime",
     ],
 )
 

--- a/deploy/artifacts/release.ts
+++ b/deploy/artifacts/release.ts
@@ -31,15 +31,16 @@ async function main() {
 	const mappings = process.argv.slice(2).map(v => v.split('='));
 
 	const ab = await Promise.all(
-		mappings.map(async ([name, file]) =>
-			await Github.rest.repos.uploadReleaseAsset({
-				owner: context.repo.owner,
-				repo: context.repo.repo,
-				release_id: (await release).data.id,
-				name,
-				// https://github.com/octokit/octokit.js/discussions/2087#discussioncomment-646569
-				data: (await fs.readFile(file)) as unknown as string,
-			})
+		mappings.map(
+			async ([name, file]) =>
+				await Github.rest.repos.uploadReleaseAsset({
+					owner: context.repo.owner,
+					repo: context.repo.repo,
+					release_id: (await release).data.id,
+					name,
+					// https://github.com/octokit/octokit.js/discussions/2087#discussioncomment-646569
+					data: (await fs.readFile(file)) as unknown as string,
+				})
 		)
 	);
 


### PR DESCRIPTION
- Releases are named for commit hash; actually include build artifacts (#112)
- Use SHA for release artifacts (#113)
- create synthetic tag name for releases (#115)
- try to use bazel node_modules for builds (#114)
- fix releases (#116)
- try to make bazelisk work again (#117)
- rootpath (#118)
- Mime (#119)
- yarn fix
