### PR TITLE
bazel cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,18 +47,10 @@ jobs:
             ~/.cache/bazelisk
             ~/.cache/bazel
           key: ${{ runner.os }}-${{ env.cache-name }}
-      - name: Directly affected tests
-        run: yarn test
-        env:
-          STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
-          STEAM_PASSWORD: ${{ secrets.STEAM_PASSWORD }}
       - name: All tests
         # Use npx to try to generate only
         # bazel generated node_modules
         run: bazelisk test //...
-        env:
-          STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
-          STEAM_PASSWORD: ${{ secrets.STEAM_PASSWORD }}
 
 
   deployment:
@@ -87,8 +79,6 @@ jobs:
         run: bazelisk //deploy:deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
-          STEAM_PASSWORD: ${{ secrets.STEAM_PASSWORD }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_SECRET }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,15 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '16'
+      - name: Restore bazel cache
+        uses: actions/cache@v2.1.4
+        env:
+          cache-name: bazel-cache
+        with:
+          path: |
+            ~/.cache/bazelisk
+            ~/.cache/bazel
+          key: ${{ runner.os }}-${{ env.cache-name }}
       - name: Directly affected tests
         run: yarn test
         env:
@@ -46,7 +55,7 @@ jobs:
       - name: All tests
         # Use npx to try to generate only
         # bazel generated node_modules
-        run: yarn run bazelisk test //...
+        run: bazelisk test //...
         env:
           STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}
           STEAM_PASSWORD: ${{ secrets.STEAM_PASSWORD }}
@@ -63,10 +72,19 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '16'
+      - name: Restore bazel cache
+        uses: actions/cache@v2.1.4
+        env:
+          cache-name: bazel-cache
+        with:
+          path: |
+            ~/.cache/bazelisk
+            ~/.cache/bazel
+          key: ${{ runner.os }}-${{ env.cache-name }}
       - name: Deploy
         # Use npx to try to generate only
         # bazel generated node_modules
-        run: yarn run bazelisk run //deploy:deploy
+        run: bazelisk //deploy:deploy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           STEAM_USERNAME: ${{ secrets.STEAM_USERNAME }}


### PR DESCRIPTION
- yarn fix (#122)
- use integrated CI, and automerge dependabot complaints (#123)
- tidy up the root dir a bit by moving jest out to its own folder (#124)
- move go formatting tools into go/fmt (#126)
- Change workflow name to 'ci' (#129)
- Move tools/bazel into bzl/ (#128)
- Cache bazel
