### PR TITLE
push versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
         # bazel generated node_modules
         run: bazelisk run //deploy:deploy
         env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/deploy/BUILD
+++ b/deploy/BUILD
@@ -9,10 +9,6 @@ BUILD_ARTIFACTS = {
     "svgshot.tar.gz": "//ts/cmd/svgshot:svgshot.tgz",
 }
 
-NPM_PACKAGES = [
-    "//ts/cmd/svgshot:npm_pkg.publish",
-]
-
 RELEASE_MESSAGE = "This release contains the following build artifacts:\n" + "\n".join([
     "   - " + output + " ← " + input
     for output, input in BUILD_ARTIFACTS.items()
@@ -37,7 +33,10 @@ ts_project(
 
 nodejs_binary(
     name = "release",
-    data = BUILD_ARTIFACTS.values() + [":release_message"],
+    data = BUILD_ARTIFACTS.values() + [
+        ":release_message",
+        "//ts/cmd/svgshot:npm_pkg.publish",
+    ],
     entry_point = "release.js",
     templated_args = [
         "--body",

--- a/deploy/BUILD
+++ b/deploy/BUILD
@@ -9,6 +9,10 @@ BUILD_ARTIFACTS = {
     "svgshot.tar.gz": "//ts/cmd/svgshot:svgshot.tgz",
 }
 
+NPM_PACKAGES = [
+    "//ts/cmd/svgshot:npm_pkg.publish",
+]
+
 RELEASE_MESSAGE = "This release contains the following build artifacts:\n" + "\n".join([
     "   - " + output + " ← " + input
     for output, input in BUILD_ARTIFACTS.items()

--- a/js/npm/BUILD
+++ b/js/npm/BUILD
@@ -1,0 +1,1 @@
+# Nothing exported here. Yet!

--- a/js/npm/package_json/rules.bzl
+++ b/js/npm/package_json/rules.bzl
@@ -1,15 +1,10 @@
 load("//:rules.bzl", "nodejs_binary")
-load("//bzl/versioning:rules.bzl", "bump_on_change_test", "semver_version")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
-load("//js/api-extractor:rules.bzl", "api_extractor")
-load("@rules_pkg//pkg:pkg.bzl", "pkg_zip")
 
 def package_json(name, targets, template, version):
     """
     Generate a package.json for a given target.
     """
     query_expression = "deps(" + ", ".join([str(Label("//" + native.package_name()).relative(target)) for target in targets]) + ", 1)"
-    print(query_expression)
     genquery_name = name + "_deps"
     native.genquery(
         name = genquery_name,
@@ -56,85 +51,4 @@ def package_json(name, targets, template, version):
               ),
         outs = ["package.json"],
         tools = [genrule_name],
-    )
-
-def npm_pkg(
-        name,
-        package_name,
-        pkg_json_base,
-        srcs = [],
-        deps = [],
-        version_lock = None,
-        api_lock = None,
-        major_version = None,
-        minor_version = None,
-        patch_version = None,
-        test_version_on_main = False,
-        entry_point = None,
-        tgz = None,
-        visibility = None):
-    external_api_root = entry_point[:entry_point.find(".")]
-    external_api_dts_root = external_api_root + ".d.ts"
-
-    semver_version(
-        name = "version",
-        major = "version/MAJOR",
-        minor = "version/MINOR",
-        patch = "version/PATCH",
-    )
-
-    pkg_json_name = name + "_package_json"
-    package_json(
-        name = pkg_json_name,
-        # Won't be srcs I am fairly sure? because srcs are never
-        # generated and so can't have deps
-        targets = deps,
-        template = pkg_json_base,
-        version = ":version",
-    )
-
-    lockfile_name = name + "_lockfile"
-    native.genrule(
-        name = name + "_lockfile",
-        srcs = ["//:yarn.lock"],
-        outs = ["yarn.lock"],
-        cmd = "cp $< $@",
-    )
-
-    api_extractor(
-        name = name + "_extracted_api",
-        entry_point = external_api_dts_root,
-        srcs = srcs + deps,
-        report = "api_gen.md",
-    )
-
-    pkg_srcs = srcs
-    pkg_deps = deps + [pkg_json_name, lockfile_name]
-    pkg_npm(
-        name = name,
-        package_name = package_name,
-        srcs = pkg_srcs,
-        deps = pkg_deps,
-        tgz = tgz,
-        visibility = visibility,
-    )
-
-    # Test that ensures at least a minor bump happens when
-    # a change in files occurs.
-    bump_on_change_test(
-        name = "version_lock",
-        srcs = pkg_srcs + pkg_deps,
-        version = minor_version,
-        run_on_main = test_version_on_main,
-        version_lock = "version.lock",
-    )
-
-    # Test that ensures that a major bump happens when a change
-    # in API schema occurs.
-    bump_on_change_test(
-        name = "api_change_lock",
-        srcs = ["api_gen.md"],
-        version = major_version,
-        run_on_main = test_version_on_main,
-        version_lock = api_lock,
     )

--- a/js/npm/rules.bzl
+++ b/js/npm/rules.bzl
@@ -1,0 +1,85 @@
+load("//bzl/versioning:rules.bzl", "bump_on_change_test", "semver_version")
+load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+load("//js/api-extractor:rules.bzl", "api_extractor")
+load("//js/npm/package_json:rules.bzl", "package_json")
+
+def npm_pkg(
+        name,
+        package_name,
+        pkg_json_base,
+        srcs = [],
+        deps = [],
+        version_lock = None,
+        api_lock = None,
+        major_version = None,
+        minor_version = None,
+        patch_version = None,
+        test_version_on_main = False,
+        entry_point = None,
+        tgz = None,
+        visibility = None):
+    external_api_root = entry_point[:entry_point.find(".")]
+    external_api_dts_root = external_api_root + ".d.ts"
+
+    semver_version(
+        name = "version",
+        major = "version/MAJOR",
+        minor = "version/MINOR",
+        patch = "version/PATCH",
+    )
+
+    pkg_json_name = name + "_package_json"
+    package_json(
+        name = pkg_json_name,
+        # Won't be srcs I am fairly sure? because srcs are never
+        # generated and so can't have deps
+        targets = deps,
+        template = pkg_json_base,
+        version = ":version",
+    )
+
+    lockfile_name = name + "_lockfile"
+    native.genrule(
+        name = name + "_lockfile",
+        srcs = ["//:yarn.lock"],
+        outs = ["yarn.lock"],
+        cmd = "cp $< $@",
+    )
+
+    api_extractor(
+        name = name + "_extracted_api",
+        entry_point = external_api_dts_root,
+        srcs = srcs + deps,
+        report = "api_gen.md",
+    )
+
+    pkg_srcs = srcs
+    pkg_deps = deps + [pkg_json_name, lockfile_name]
+    pkg_npm(
+        name = name,
+        package_name = package_name,
+        srcs = pkg_srcs,
+        deps = pkg_deps,
+        tgz = tgz,
+        visibility = visibility,
+    )
+
+    # Test that ensures at least a minor bump happens when
+    # a change in files occurs.
+    bump_on_change_test(
+        name = "version_lock",
+        srcs = pkg_srcs + pkg_deps,
+        version = minor_version,
+        run_on_main = test_version_on_main,
+        version_lock = "version.lock",
+    )
+
+    # Test that ensures that a major bump happens when a change
+    # in API schema occurs.
+    bump_on_change_test(
+        name = "api_change_lock",
+        srcs = ["api_gen.md"],
+        version = major_version,
+        run_on_main = test_version_on_main,
+        version_lock = api_lock,
+    )

--- a/ts/cmd/svgshot/BUILD
+++ b/ts/cmd/svgshot/BUILD
@@ -1,5 +1,5 @@
 load("//:rules.bzl", "jest_test", "nodejs_binary", "ts_project")
-load("//js/npm/package_json:rules.bzl", "npm_pkg")
+load("//js/npm:rules.bzl", "npm_pkg")
 
 ts_project(
     name = "project",

--- a/ts/cmd/svgshot/BUILD
+++ b/ts/cmd/svgshot/BUILD
@@ -1,6 +1,8 @@
 load("//:rules.bzl", "jest_test", "nodejs_binary", "ts_project")
 load("//js/npm:rules.bzl", "npm_pkg")
 
+package(default_visibility = ["//deploy:__subpackages__"])
+
 ts_project(
     name = "project",
     srcs = [


### PR DESCRIPTION
- remember to include release message https://github.com/Zemnmez/monorepo/runs/6906627705\?check_suite_focus\=true
- fixes
- Fix issue with deploy:
- Bump @bazel/bazelisk from 1.11.0 to 1.12.0
- Bump aws-sdk from 2.1154.0 to 2.1155.0
- Bump electron-to-chromium from 1.4.155 to 1.4.157
- Bump caniuse-lite from 1.0.30001352 to 1.0.30001354
- Bump @types/node from 17.0.43 to 18.0.0
- Bump esbuild from 0.14.43 to 0.14.44
- Bump @actions/core from 1.8.2 to 1.9.0
- move npm rules into npm folder
