### PR TITLE
auto update

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -1,0 +1,18 @@
+name: Auto-update
+# Auto-update only listens to `push` events.
+# If a pull request is already outdated when enabling auto-merge, manually click on the "Update branch" button a first time to avoid having to wait for another commit to land on the base branch for the pull request to be updated.
+on: push
+# If pull requests are always based on the same branches, only triggering the workflow when these branches receive new commits will minimize the workflow execution.
+# on:
+#   push:
+#     branches:
+#       - main
+
+jobs:
+  Auto:
+    name: Auto-update
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tibdex/auto-update@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- remember to include release message https://github.com/Zemnmez/monorepo/runs/6906627705\?check_suite_focus\=true
- fixes
- Fix issue with deploy:
- Bump @bazel/bazelisk from 1.11.0 to 1.12.0
- Bump aws-sdk from 2.1154.0 to 2.1155.0
- Bump electron-to-chromium from 1.4.155 to 1.4.157
- Bump caniuse-lite from 1.0.30001352 to 1.0.30001354
- Bump @types/node from 17.0.43 to 18.0.0
- Bump esbuild from 0.14.43 to 0.14.44
- Bump @actions/core from 1.8.2 to 1.9.0
- Only bother committing if we actually made any changes https://github.com/Zemnmez/monorepo/runs/6909169682?check_suite_focus=true
- Add auto-update workflow
