### PR TITLE
npm token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,10 @@ jobs:
       - name: Deploy
         # Use npx to try to generate only
         # bazel generated node_modules
-        run: bazelisk run //deploy:deploy
+        run: |
+          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}'> .npmrc
+          bazelisk run //deploy:deploy
+        shell: bash
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}


### PR DESCRIPTION
- release fixes
- check off versioning.md tasks
- Revert "release fixes"
- Fix previously broken commit
- apparently this is needed so that NPM picks up the auth token
