### PR TITLE
fix csvpretty install instructions

### DIFF
--- a/go/cmd/csvpretty/README.md
+++ b/go/cmd/csvpretty/README.md
@@ -51,14 +51,14 @@ Installation
 
 With a working Go setup, and `$GOPATH/bin` in your `$PATH`:
 ```bash
-go get github.com/zemnmez/csvpretty -u
+go get github.com/zemnmez/monorepo/go/cmd/csvpretty -u
 ```
 
 If you want to quickly use `csvpretty` and you have `go` installed, you can
 just:
 
 ```bash
-go run github.com/zemnmez/csvpretty
+go run github.com/zemnmez/monorepo/go/cmd/csvpretty
 ```
 
 With whatever args you desire.


### PR DESCRIPTION
- Upgrade rules_nodejs for amd64
- Remove direct esbuild dep
- Remove need for weird directory hack
- Remove pulumi (for now). It's shit anyway
- Allow amd64
- Run fixers and modify to work on systems with no 'realpath'
- note on readlink
- attempt to fix rootDirs
- use swc
- upgrade some bazel deps
- use swc
- just kill me
- kill me
- still not working
- oops
- nothing is sticking
- new bazel
- remove swc
- actually comment these out correctly
- Bump @types/jest from 28.1.4 to 28.1.5
- add logic to minimize extraneous stuff from lockfiles
- fix csvpretty install instructions
