### PR TITLE
do sync

### DIFF
--- a/js/npm/rules.bzl
+++ b/js/npm/rules.bzl
@@ -54,6 +54,7 @@ def npm_pkg(
         entry_point = external_api_dts_root,
         srcs = srcs + deps,
         report = "api_gen.md",
+        publicTrimmedRollup = "public.d.ts"
     )
 
     pkg_srcs = srcs

--- a/ts/do-sync/BUILD
+++ b/ts/do-sync/BUILD
@@ -27,6 +27,5 @@ npm_pkg(
     pkg_json_base = "package.template.json",
     tgz = "do-sync.tgz",
     version_lock = ".version.lock",
-    visibility = ["//deploy:__subpackages__"],
     deps = [":do-sync"],
 )

--- a/ts/do-sync/testing/BUILD
+++ b/ts/do-sync/testing/BUILD
@@ -1,4 +1,5 @@
 load("//ts:rules.bzl", "jest_test", "ts_project")
+load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
 
 package(default_visibility = [
     ":__subpackages__",
@@ -7,13 +8,19 @@ package(default_visibility = [
 
 ts_project(
     name = "project",
-    srcs = glob(["**/*.ts"]),
+    srcs = glob(["**/*.ts"]) + [ ":npm_pkg" ],
     deps = [
-        "//ts/do-sync",
         "@npm//@types/jest",
         "@npm//@types/sharp",
         "@npm//sharp",
     ],
+)
+
+
+
+js_library(
+    name = "npm_pkg",
+    deps = ["//ts/do-sync:npm_pkg" ]
 )
 
 jest_test(

--- a/ts/do-sync/testing/doSync_test.ts
+++ b/ts/do-sync/testing/doSync_test.ts
@@ -1,4 +1,4 @@
-import { doSync, JSONObject } from 'ts/do-sync';
+import { doSync, JSONObject } from 'ts/do-sync/npm_pkg';
 import sharpT from 'sharp';
 
 const pixel =


### PR DESCRIPTION
- Bump @microsoft/api-extractor from 7.28.5 to 7.28.6
- Bump react-spring from 9.5.0 to 9.5.1
- update ck3
- need this
- Bump caniuse-lite from 1.0.30001367 to 1.0.30001368
- Bump eslint-plugin-jsx-a11y from 6.6.0 to 6.6.1
- Bump eslint-config-next from 12.2.2 to 12.2.3
- more testing on deploy
- Bump aws-sdk from 2.1179.0 to 2.1181.0
- Remove the auto update workflow for now.
- Bump date-fns from 2.28.0 to 2.29.1
- Bump puppeteer from 15.4.0 to 15.5.0
- Bump react-spring from 9.5.1 to 9.5.2
- Bump @types/node from 18.0.6 to 18.6.0
- Bump caniuse-lite from 1.0.30001368 to 1.0.30001370
- run do-sync tests on npm package
