### PR TITLE
fix exec checks

### DIFF
--- a/deploy/program.ts
+++ b/deploy/program.ts
@@ -58,7 +58,7 @@ const pulumiDeploy =
 				)
 					throw new Error('Missing environment variables.');
 
-				exec(buildTag);
+				exec(runfiles.resolveWorkspaceRelative(buildTag));
 			},
 		};
 	};
@@ -257,12 +257,8 @@ export const release =
 		) => void releaseUploads.push([file, content]);
 
 		const exec: Context['exec'] = dryRun
-			? async (filename: string) => {
-					if (filename == '')
-						throw new Error('Request to exec empty string');
-			  }
+			? async (filename: string) => await fs.access(filename)
 			: async (filename: string) => {
-					console.log('executing', filename);
 					return void (await promisify(child_process.execFile)(
 						filename
 					));


### PR DESCRIPTION
- use ts_project directly for pulumi
- more pulumi stuff
- pulumi success :)
- amend
- Bump esbuild-css-modules-plugin from 2.5.1 to 2.5.2
- Bump caniuse-lite from 1.0.30001377 to 1.0.30001378
- Bump date-fns from 2.29.1 to 2.29.2
- Bump electron-to-chromium from 1.4.222 to 1.4.225
- Bump aws-sdk from 2.1196.0 to 2.1198.0
- Bump setuptools from 65.0.1 to 65.1.0
- Bump @microsoft/api-extractor from 7.29.2 to 7.29.3
- Bump @microsoft/api-documenter from 7.19.4 to 7.19.5
- Ensure all exec'd files exist in dry run.
