### PR TITLE
Attempt fix for automatic deploys.

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -12,8 +12,6 @@ on:   # yamllint disable-line rule:truthy
 
 jobs:
   Test:
-    # This runs just the tests that are specified not to run on main
-    if: github.ref == 'refs/heads/versioned'
     name: Tests (for merging into versioned branch)
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The test cycle was being cancelled by the fact that versioning does not
run on main. This then also cancelled the automatic deploy.
