### PR TITLE
test for incorrect package name

### DIFF
--- a/deploy/program.ts
+++ b/deploy/program.ts
@@ -92,6 +92,10 @@ interface NpmPackageInfo {
 const npmPackage =
 	(packageName: string, buildTag: string) =>
 	async (): Promise<NpmPackageInfo> => {
+		if (!buildTag.includes(packageName))
+			throw new Error(
+				`Build tag ${buildTag} does not include package name ${packageName}. Are you sure it's correct?`
+			);
 		return {
 			buildTag,
 			kind: 'npm_publication',
@@ -364,7 +368,7 @@ export const program = ({
 				),
 				artifact('svgshot.tar.gz', '//ts/cmd/svgshot/svgshot.tgz'),
 				npmPackage('svgshot', '//ts/cmd/svgshot/npm_pkg.publish.sh'),
-				npmPackage('svgshot', '//ts/do-sync/npm_pkg.publish.sh'),
+				npmPackage('do-sync', '//ts/do-sync/npm_pkg.publish.sh'),
 				artifact('svgshot.tar.gz', '//ts/do-sync/do-sync.tgz'),
 				artifact(
 					'knowitwhenyouseeit.tar.gz',


### PR DESCRIPTION
- suspend github auth failure until execution of the release function. This ensures that the releasers can individually run and fail.
- fix
- Bump @typescript-eslint/parser from 5.35.1 to 5.36.1
- Bump caniuse-lite from 1.0.30001384 to 1.0.30001385
- Bump electron-to-chromium from 1.4.234 to 1.4.237
- Bump aws-sdk from 2.1205.0 to 2.1206.0
- Bump @fortawesome/fontawesome-svg-core from 6.1.2 to 6.2.0
- Bump @microsoft/api-documenter from 7.19.7 to 7.19.9
- Bump @types/react from 18.0.17 to 18.0.18
- Bump @typescript-eslint/eslint-plugin from 5.36.0 to 5.36.1
- Bump @fortawesome/free-solid-svg-icons from 6.1.2 to 6.2.0
- test for incorrect npm package name
