### PR TITLE
force renovate to make PRs even where they were closed

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
 	"platformAutomerge": true,
 	"platformCommit": true,
 	"allowScripts": true,
+	"recreateClosed": true,
 	"gitIgnoredAuthors": [ "zemnmez+renovate@gmail.com" ],
     "autodiscoverFilter": [ "Zemnmez/monorepo" ],
 	"allowedPostUpgradeCommands": [
@@ -21,7 +22,8 @@
 					"CARGO_BAZEL_REPIN=1 npx --yes @bazel/bazelisk sync --only=cargo"
 				],
 				"executionMode": "branch",
-				"fileFilters": [ "Cargo.Bazel.lock", "Cargo.toml", "cargo-bazel-lock.json" ]
+				"fileFilters": [ "Cargo.Bazel.lock", "Cargo.toml", "cargo-bazel-lock.json" ],
+				"recreateClosed": true
 			}
 		}
 	]


### PR DESCRIPTION
I'm in a predicament where my PAT means 'zemnmez' made most of the PRs. If I close them, Renovate thinks I don't want them merged; and if I open them, Renovate thinks someone else edited them. This should force renovate to re-open its own PRs for these.

If this doesn't work, I can add it to packageRules.