### PR TITLE
Just use git refs for next.js versions

### DIFF
--- a/ts/next.js/rules.bzl
+++ b/ts/next.js/rules.bzl
@@ -22,7 +22,7 @@ def next_project(name, srcs, **kwargs):
         outs = ["buildid.sed"],
         srcs = [name + "_latest_commit"],
         cmd_bash = """
-            echo "s|/\\*REPLACE\\*/ throw new Error() /\\*REPLACE\\*/|return \\"https://github.com/zemnmez/monorepo/commit/$$(cat $(location """ +
+            echo "s|/\\*REPLACE\\*/ throw new Error() /\\*REPLACE\\*/|return \\"$$(cat $(location """ +
                    name +
                    """_latest_commit))\\"|g" >$@
         """,


### PR DESCRIPTION
Next.js was silently choking on anything else, making files that
obviously cant work due to /
