### PR TITLE
simplify and abstract build files

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,11 +6,10 @@
 #   so that ts_library rules still use it by default.
 #   See https://www.npmjs.com/package/@bazel/typescript#installation
 
-load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+load("//js:rules.bzl", "copy_to_bin", "js_library")
 load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 load("@npm//@bazel/esbuild:esbuild_config.bzl", "esbuild_config")
-load("//:rules.bzl", "ts_config")
-load("@build_bazel_rules_nodejs//:index.bzl", "copy_to_bin")
+load("//ts:rules.bzl", "ts_config")
 load("@npm//renovate:index.bzl", "renovate_config_validator_test")
 
 package(default_visibility = [":__subpackages__"])

--- a/VERSION/BUILD.bazel
+++ b/VERSION/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//bzl/versioning:rules.bzl", "bump_bin", "semver_version")
+load("//bzl/versioning:rules.bzl", "semver_version")
 
 package(default_visibility = ["//deploy:__subpackages__"])
 

--- a/bzl/hash/test/BUILD.bazel
+++ b/bzl/hash/test/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//bzl/hash:rules.bzl", "hashes")
-load("@build_bazel_rules_nodejs//:index.bzl", "generated_file_test")
+load("//js:rules.bzl", "generated_file_test")
 
 hashes(
     name = "hashes",

--- a/bzl/versioning/rules.bzl
+++ b/bzl/versioning/rules.bzl
@@ -1,5 +1,5 @@
 load("//bzl/hash:rules.bzl", "hashes")
-load("@build_bazel_rules_nodejs//:index.bzl", "generated_file_test")
+load("//js:rules.bzl", "generated_file_test")
 load("@rules_python//python:defs.bzl", "py_binary")
 
 def semver_version(name, major = None, minor = None, patch = None, **kwargs):

--- a/bzl/versioning/test/semver_version/BUILD.bazel
+++ b/bzl/versioning/test/semver_version/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//bzl/versioning:rules.bzl", "semver_version")
-load("@build_bazel_rules_nodejs//:index.bzl", "generated_file_test")
+load("//js:rules.bzl", "generated_file_test")
 
 semver_version(
     name = "version",

--- a/css/lint/BUILD.bazel
+++ b/css/lint/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+load("//js:rules.bzl", "js_library")
 
 package(default_visibility = ["//:__subpackages__"])
 

--- a/css/rules.bzl
+++ b/css/rules.bzl
@@ -1,4 +1,3 @@
-load("//ts:rules.bzl", "ts_project")
 load("//css:providers.bzl", "CSSLibraryInfo", "css_library_info")
 load("//css/lint:rules.bzl", "css_lint")
 load("//rs/css/module:rules.bzl", "css_module_rule")

--- a/deploy/BUILD.bazel
+++ b/deploy/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//ts:rules.bzl", "jest_test", "ts_project")
-load("//:rules.bzl", "nodejs_binary", "nodejs_test")
+load("//js:rules.bzl", "nodejs_binary", "nodejs_test")
 
 package(default_visibility = ["//deploy:__subpackages__"])
 

--- a/git/testing/BUILD.bazel
+++ b/git/testing/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//git:rules.bzl", "git_commit_affecting_files", "source_files_for_rule")
-load("@build_bazel_rules_nodejs//:index.bzl", "generated_file_test")
+load("//js:rules.bzl", "generated_file_test")
 
 git_commit_affecting_files(
     name = "affected_files_basic_ref",

--- a/go/BUILD.bazel
+++ b/go/BUILD.bazel
@@ -1,0 +1,2 @@
+# no rules in this file, but it's required for
+# bazel to consider this folder a package.

--- a/go/archive/zip/ziputil/BUILD.bazel
+++ b/go/archive/zip/ziputil/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//:rules.bzl", "go_library")
+load("//go:rules.bzl", "go_library")
 
 go_library(
     name = "ziputil",

--- a/go/cmd/csvpretty/BUILD.bazel
+++ b/go/cmd/csvpretty/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//:rules.bzl", "go_binary")
+load("//go:rules.bzl", "go_binary")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 
 go_binary(

--- a/go/cmd/zipdir/BUILD.bazel
+++ b/go/cmd/zipdir/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//:rules.bzl", "go_binary")
+load("//go:rules.bzl", "go_binary")
 
 go_binary(
     name = "zipdir",

--- a/go/cmd/zipfiles/BUILD.bazel
+++ b/go/cmd/zipfiles/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//:rules.bzl", "go_binary")
+load("//go:rules.bzl", "go_binary")
 
 go_binary(
     name = "zipfiles",

--- a/go/flag/flagutil/BUILD.bazel
+++ b/go/flag/flagutil/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//:rules.bzl", "go_library")
+load("//go:rules.bzl", "go_library")
 
 go_library(
     name = "flagutil",

--- a/go/rules.bzl
+++ b/go/rules.bzl
@@ -1,16 +1,5 @@
-load("//go/fmt:rules.bzl", _test_go_fmt = "test_go_fmt")
 load("@io_bazel_rules_go//go:def.bzl", _go_binary = "go_binary", _go_library = "go_library", _go_test = "go_test")
-load("@npm//@bazel/typescript:index.bzl", _ts_config = "ts_config")
-load("@build_bazel_rules_nodejs//:index.bzl", _nodejs_binary = "nodejs_binary", _nodejs_test = "nodejs_test")
-
-def nodejs_binary(link_workspace_root = True, **kwargs):
-    _nodejs_binary(link_workspace_root = link_workspace_root, **kwargs)
-
-def nodejs_test(link_workspace_root = True, **kwargs):
-    _nodejs_test(link_workspace_root = link_workspace_root, **kwargs)
-
-def ts_config(**kwargs):
-    _ts_config(**kwargs)
+load("//go/fmt:rules.bzl", _test_go_fmt = "test_go_fmt")
 
 def go_binary(name = None, embedsrcs = None, importpath = None, deps = [], **kwargs):
     _go_binary(

--- a/js/BUILD.bazel
+++ b/js/BUILD.bazel
@@ -1,0 +1,1 @@
+# Nothing in here yet!

--- a/js/api-documenter/rules.bzl
+++ b/js/api-documenter/rules.bzl
@@ -1,4 +1,3 @@
-load("@build_bazel_rules_nodejs//:providers.bzl", "DeclarationInfo")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 
 def _api_documenter_impl(ctx):

--- a/js/npm/package_json/rules.bzl
+++ b/js/npm/package_json/rules.bzl
@@ -1,4 +1,4 @@
-load("//:rules.bzl", "nodejs_binary")
+load("//js:rules.bzl", "nodejs_binary")
 
 def package_json(name, targets, template, version, depSpec):
     """

--- a/js/npm/rules.bzl
+++ b/js/npm/rules.bzl
@@ -1,8 +1,7 @@
 load("//bzl/versioning:rules.bzl", "bump_on_change_test", "semver_version")
 load("//js/api-documenter:rules.bzl", "api_documenter")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
-load("//js/npm/yarn/lock:rules.bzl", "lockfile_minimize")
-load("@build_bazel_rules_nodejs//:index.bzl", "pkg_npm")
+load("//js:rules.bzl", "pkg_npm")
 load("//js/api-extractor:rules.bzl", "api_extractor")
 load("//js/npm/package_json:rules.bzl", "package_json")
 

--- a/js/rules.bzl
+++ b/js/rules.bzl
@@ -1,0 +1,19 @@
+load("@build_bazel_rules_nodejs//:index.bzl", _generated_file_test = "generated_file_test", _js_library = "js_library", _nodejs_binary = "nodejs_binary", _nodejs_test = "nodejs_test", _copy_to_bin = "copy_to_bin", _pkg_npm = "pkg_npm")
+
+def generated_file_test(name, **kwargs):
+    _generated_file_test(name = name, **kwargs)
+
+def nodejs_binary(name, link_workspace_root = True, **kwargs):
+    _nodejs_binary(name = name, link_workspace_root = link_workspace_root, **kwargs)
+
+def nodejs_test(name, link_workspace_root = True, **kwargs):
+    _nodejs_test(name = name, link_workspace_root = link_workspace_root, **kwargs)
+
+def js_library(name, **kwargs):
+    _js_library(name = name, **kwargs)
+
+def copy_to_bin(name, **kwargs):
+    _copy_to_bin(name = name, **kwargs)
+
+def pkg_npm(name, **kwargs):
+    _pkg_npm(name = name, **kwargs)

--- a/project/cultist/gen/BUILD.bazel
+++ b/project/cultist/gen/BUILD.bazel
@@ -1,8 +1,8 @@
 load("//ts:rules.bzl", "ts_project")
-load("//:rules.bzl", "nodejs_binary")
+load("//js:rules.bzl", "nodejs_binary")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@com_google_protobuf//:protobuf.bzl", "py_proto_library")
-load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+load("//js:rules.bzl", "js_library")
 
 package(default_visibility = [
     "//project/cultist:__subpackages__",

--- a/project/cultist/multiplayer/BUILD.bazel
+++ b/project/cultist/multiplayer/BUILD.bazel
@@ -1,5 +1,4 @@
 load("//ts:rules.bzl", "ts_project")
-load("//ts/react/server:rules.bzl", "web_app")
 
 ts_project(
     name = "index",

--- a/project/zemn.me/BUILD.bazel
+++ b/project/zemn.me/BUILD.bazel
@@ -1,6 +1,4 @@
 load("//ts:rules.bzl", "ts_project")
-load("//ts/react/server:rules.bzl", "web_app")
-load("//css:rules.bzl", "css_library")
 
 ts_project(
     name = "ts",

--- a/project/zemn.me/bio/sort_tool/BUILD.bazel
+++ b/project/zemn.me/bio/sort_tool/BUILD.bazel
@@ -1,5 +1,5 @@
 load("//ts:rules.bzl", "ts_project")
-load("//:rules.bzl", "nodejs_binary")
+load("//js:rules.bzl", "nodejs_binary")
 
 ts_project(
     name = "sort_tool",

--- a/rs/cargo/testing/BUILD.bazel
+++ b/rs/cargo/testing/BUILD.bazel
@@ -1,5 +1,5 @@
-load("//rs:rules.bzl", "rust_binary", "rust_doc")
-load("@build_bazel_rules_nodejs//:index.bzl", "generated_file_test")
+load("//rs:rules.bzl", "rust_binary")
+load("//js:rules.bzl", "generated_file_test")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/rs/cmd/sha256/BUILD.bazel
+++ b/rs/cmd/sha256/BUILD.bazel
@@ -1,6 +1,5 @@
 load("//rs:rules.bzl", "rust_binary")
-load("@build_bazel_rules_nodejs//:index.bzl", "generated_file_test")
-load("@rules_rust//rust:defs.bzl", "rust_test")
+load("//js:rules.bzl", "generated_file_test")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/rs/css/module/BUILD.bazel
+++ b/rs/css/module/BUILD.bazel
@@ -1,5 +1,4 @@
 load("//rs:rules.bzl", "rust_binary")
-load("@rules_rust//rust:defs.bzl", "rust_test")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/rs/css/module/testing/BUILD.bazel
+++ b/rs/css/module/testing/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_nodejs//:index.bzl", "generated_file_test")
+load("//js:rules.bzl", "generated_file_test")
 load("//rs/css/module:rules.bzl", "css_module_rule")
 
 genrule(

--- a/rs/ts/BUILD.bazel
+++ b/rs/ts/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//rs:rules.bzl", "rust_doc", "rust_library")
-load("@build_bazel_rules_nodejs//:index.bzl", "generated_file_test")
+load("//rs:rules.bzl", "rust_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/rs/ts/testing/BUILD.bazel
+++ b/rs/ts/testing/BUILD.bazel
@@ -1,5 +1,4 @@
-load("//rs:rules.bzl", "rust_binary", "rust_doc")
-load("@build_bazel_rules_nodejs//:index.bzl", "generated_file_test")
+load("//rs:rules.bzl", "rust_binary")
 load("//ts:rules.bzl", "ts_project")
 
 package(default_visibility = ["//visibility:public"])

--- a/testing/BUILD.bazel
+++ b/testing/BUILD.bazel
@@ -1,6 +1,6 @@
 load("//ts:rules.bzl", "jest_test", "ts_project")
 load("@rules_python//python:defs.bzl", "py_test")
-load("//:rules.bzl", "go_test")
+load("//go:rules.bzl", "go_test")
 
 go_test(
     name = "go_basic_test",

--- a/ts/cmd/svgshot/BUILD.bazel
+++ b/ts/cmd/svgshot/BUILD.bazel
@@ -1,6 +1,4 @@
 load("//ts:rules.bzl", "jest_test", "ts_project")
-load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
-load("//:rules.bzl", "nodejs_binary")
 load("//js/npm:rules.bzl", "npm_pkg")
 
 package(default_visibility = [

--- a/ts/do-sync/BUILD.bazel
+++ b/ts/do-sync/BUILD.bazel
@@ -1,6 +1,6 @@
 load("//ts:rules.bzl", "ts_project")
 load("//js/npm:rules.bzl", "npm_pkg")
-load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
+load("//js:rules.bzl", "js_library")
 
 package(default_visibility = [
     ":__subpackages__",

--- a/ts/esbuild/testing/css_basic/BUILD.bazel
+++ b/ts/esbuild/testing/css_basic/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@npm//@bazel/esbuild:index.bzl", "esbuild")
 load("//ts:rules.bzl", "ts_project")
 
 ts_project(

--- a/ts/knowitwhenyouseeit/BUILD.bazel
+++ b/ts/knowitwhenyouseeit/BUILD.bazel
@@ -1,6 +1,4 @@
 load("//ts:rules.bzl", "jest_test", "ts_project")
-load("@build_bazel_rules_nodejs//:index.bzl", "js_library")
-load("//:rules.bzl", "nodejs_binary")
 load("//js/npm:rules.bzl", "npm_pkg")
 
 package(default_visibility = [

--- a/ts/next.js/testing/css_module_import/project/BUILD.bazel
+++ b/ts/next.js/testing/css_module_import/project/BUILD.bazel
@@ -1,0 +1,24 @@
+# I got this file from a bad rebase but I'm scared to remove it so it's going to stay.
+
+#load("//ts:rules.bzl", "ts_project")
+#load("//ts/next.js:rules.bzl", "next_project")
+#
+#ts_project(
+#    name = "ts_sources",
+#    data = ["@npm//next/bin:next"],
+#    deps = [
+#        "//ts/math",
+#        "//ts/next.js/testing/css_module_import/remote",
+#        "@npm//@bazel/runfiles",
+#        "@npm//@types/node",
+#        "@npm//@types/react",
+#        "@npm//react",
+#        "@npm//react-dom",
+#    ],
+#)
+
+#next_project(
+#    name = "example",
+#    srcs = [":ts_sources"],
+#    distDir = "build",
+#)

--- a/ts/next.js/testing/css_module_import/remote/BUILD.bazel
+++ b/ts/next.js/testing/css_module_import/remote/BUILD.bazel
@@ -1,0 +1,18 @@
+
+#I think this came out of a bad rebase but I'm worried to delete it
+
+#load("//ts:rules.bzl", "ts_project")
+#load("//js:rules.bzl", "copy_to_bin")
+#
+#package(default_visibility = ["//ts/next.js/testing/css_module_import:__subpackages__"])
+#
+#ts_project(
+#    name = "remote",
+#    data = ["css_sources"],
+#    deps = ["//:base_defs"],
+#)
+
+#copy_to_bin(
+#    name = "css_sources",
+#    srcs = ["module.module.css"],
+#)

--- a/ts/next.js/testing/example/BUILD.bazel
+++ b/ts/next.js/testing/example/BUILD.bazel
@@ -1,4 +1,4 @@
-load("//ts:rules.bzl", "jest_test", "nodejs_binary", "ts_project")
+load("//ts:rules.bzl", "ts_project")
 load("//ts/next.js:rules.bzl", "next_project")
 
 ts_project(

--- a/ts/pulumi/BUILD.bazel
+++ b/ts/pulumi/BUILD.bazel
@@ -1,5 +1,4 @@
 load("//ts:rules.bzl", "jest_test", "nodejs_binary", "ts_project")
-load("@bazel_skylib//rules:native_binary.bzl", "native_test")
 
 package(default_visibility = ["//deploy:__subpackages__"])
 

--- a/ts/react/server/rules.bzl
+++ b/ts/react/server/rules.bzl
@@ -48,7 +48,7 @@ get_css_rule = rule(
 )
 
 def web_app(name, entry_points, srcs = [], tsconfig = "//:tsconfig", esbuild_deps = [], deps = ["//ts/react/server:index.html"], visibility = [], **kwargs):
-    deps += ["//:tsconfig.json"]
+    deps.append("//:tsconfig.json")
     native.filegroup(
         name = name + "_deps",
         srcs = deps,

--- a/ts/rules.bzl
+++ b/ts/rules.bzl
@@ -1,6 +1,6 @@
 load("//js/jest:rules.bzl", _jest_test = "jest_test")
 load("@npm//@bazel/typescript:index.bzl", _ts_config = "ts_config", _ts_project = "ts_project")
-load("@build_bazel_rules_nodejs//:index.bzl", _nodejs_binary = "nodejs_binary")
+load("//js:rules.bzl", _nodejs_binary = "nodejs_binary")
 load("@aspect_rules_swc//swc:defs.bzl", "swc_transpiler")
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("//js/eslint:rules.bzl", "eslint_test")


### PR DESCRIPTION
- Bump caniuse-lite from 1.0.30001436 to 1.0.30001439
- Bump z-schema from 5.0.3 to 5.0.4
- Bump aws-sdk from 2.1272.0 to 2.1273.0
- Bump renovate from 34.54.2 to 34.55.0
- Update Rust crate swc_atoms to 0.4.27
- Update Rust crate swc_common to 0.29.21
- Update Rust crate swc_common to 0.29.22
- Update Rust crate swc_atoms to 0.4.28
- Update Rust crate swc_atoms to 0.4.29
- Update dependency esbuild to v0.16.5
- Update Rust crate swc_common to 0.29.23
- a plan for css modules
- line length
- Bump node-releases from 2.0.6 to 2.0.7
- Bump axe-core from 4.5.2 to 4.6.0
- Bump internal-slot from 1.0.3 to 1.0.4
- Bump aws-sdk from 2.1273.0 to 2.1274.0
- Bump @types/node from 18.11.12 to 18.11.15
- Update dependency esbuild to v0.16.6
- Update dependency build_bazel_rules_nodejs to v5.8.0
- Update renovatebot/github-action action to v34.56.0
- Update dependency esbuild to v0.16.7
- Bump axe-core from 4.6.0 to 4.6.1
- Bump renovate from 34.55.0 to 34.56.3
- Bump aws-sdk from 2.1274.0 to 2.1275.0
- Update renovatebot/github-action action to v34.56.3
- Update nextjs monorepo to v13.0.7
- Update renovatebot/github-action action to v34.57.0
- Bump renovate from 34.56.3 to 34.58.0
- Bump language-tags from 1.0.6 to 1.0.7
- Bump aws-sdk from 2.1275.0 to 2.1276.0
- Bump rxjs from 7.6.0 to 7.8.0
- Update renovatebot/github-action action to v34.58.0
- Update renovatebot/github-action action to v34.58.1
- Update dependency puppeteer to v19.4.1
- Update dependency rules_rust to v0.15.0
- Update renovatebot/github-action action to v34.59.0
- Update react-router monorepo to v6.5.0
- Update dependency @pulumi/aws to v5.24.0
- Update dependency react-spring to v9.6.1
- Update renovatebot/github-action action to v34.60.0
- Update dependency esbuild to v0.16.8
- Update dependency eslint to v8.30.0
- Update dependency aspect_rules_swc to v0.20.1
- Update renovatebot/github-action action to v34.61.0
- Update Rust crate serde_json to 1.0.90
- Update renovatebot/github-action action to v34.62.1
- Update dependency esbuild to v0.16.9
- Update renovatebot/github-action action to v34.63.0
- Update Rust crate swc_atoms to 0.4.30
- Update renovatebot/github-action action to v34.63.1
- Update Rust crate serde_json to 1.0.91
- Bump install-artifact-from-github from 1.3.1 to 1.3.2
- Update dependency glob-promise to v5.0.1
- Update renovatebot/github-action action to v34.63.2
- Update dependency bazel to v6.0.0
- Update typescript-eslint monorepo to v5.47.0
- Update dependency pulumi_cli to v3.50.0
- Update dependency esbuild to v0.16.10
- Bump aws-sdk from 2.1276.0 to 2.1278.0
- Bump ws from 8.10.0 to 8.11.0
- Update dependency @microsoft/api-documenter to v7.19.27
- Bump @pulumi/pulumi from 3.49.0 to 3.50.0
- Bump node-releases from 2.0.7 to 2.0.8
- Bump renovate from 34.58.0 to 34.65.1
- Bump @types/node from 18.11.15 to 18.11.17
- Update Rust crate swc_atoms to 0.4.31
- Update Rust crate swc_common to 0.29.24
- Update renovatebot/github-action action to v34.65.1
- Update renovatebot/github-action action to v34.66.1
- Bump renovate from 34.65.1 to 34.67.0
- Bump aws-sdk from 2.1278.0 to 2.1279.0
- Bump z-schema from 5.0.4 to 5.0.5
- Update Rust crate clap to 4.0.30
- Update Rust crate swc_common to 0.29.25
- Update Rust crate swc_atoms to 0.4.32
- Update renovatebot/github-action action to v34.67.0
- Update actions/cache action to v3.2.0
- Update renovatebot/github-action action to v34.68.0
- Update dependency sharp to v0.31.3
- Update dependency pulumi_cli to v3.50.1
- Update react-router monorepo to v6.6.0
- Update renovatebot/github-action action to v34.70.0
- Update dependency glob-promise to v6
- Bump @pulumi/pulumi from 3.50.0 to 3.50.2
- Bump aws-sdk from 2.1279.0 to 2.1280.0
- Bump caniuse-lite from 1.0.30001439 to 1.0.30001441
- Bump node-gyp from 9.3.0 to 9.3.1
- Bump renovate from 34.67.0 to 34.70.0
- Update dependency pulumi_cli to v3.50.2
- Update nextjs monorepo to v13.1.0
- Update dependency immutable to v4.2.0
- Update renovatebot/github-action action to v34.70.1
- Update Rust crate clap to 4.0.31
- Update dependency @pulumi/aws to v5.25.0
- Update Rust crate clap to 4.0.32
- Bump aws-sdk from 2.1280.0 to 2.1281.0
- Bump renovate from 34.70.0 to 34.70.4
- Update renovatebot/github-action action to v34.70.4
- Update actions/cache action to v3.2.1
- Update dependency @types/react-dom to v18.0.10
- Update dependency immutable to v4.2.1
- Update react-router monorepo to v6.6.1
- Update renovatebot/github-action action to v34.72.1
- Update renovatebot/github-action action to v34.72.2
- Update nextjs monorepo to v13.1.1
- Update renovatebot/github-action action to v34.73.0
- Update dependency @swc/cli to v0.1.58
- Update renovatebot/github-action action to v34.73.1
- Update dependency @swc/cli to v0.1.59
- Update renovatebot/github-action action to v34.73.3
- Update typescript-eslint monorepo to v5.47.1
- Bump aws-sdk from 2.1281.0 to 2.1282.0
- Bump core-js-pure from 3.26.1 to 3.27.0
- Bump @types/node from 18.11.17 to 18.11.18
- Bump renovate from 34.70.4 to 34.74.0
- Update dependency esbuild to v0.16.11
- Update renovatebot/github-action action to v34.74.0
- Update actions/cache action to v3.2.2
- Update renovatebot/github-action action to v34.74.2
- Bump renovate from 34.74.0 to 34.74.2
- Bump aws-sdk from 2.1282.0 to 2.1283.0
- Update dependency esbuild to v0.16.12
- Bump aws-sdk from 2.1283.0 to 2.1284.0
- Update dependency stylelint to v14.16.1
- Bump aws-sdk from 2.1284.0 to 2.1285.0
- Bump core-js-pure from 3.27.0 to 3.27.1
- Bump renovate from 34.74.2 to 34.76.0
- Update renovatebot/github-action action to v34.76.0
- Update renovatebot/github-action action to v34.76.1
- Update renovatebot/github-action action to v34.76.2
- Update dependency @types/d3-scale to v4.0.3
- Update dependency @types/d3-axis to v3.0.2
- Update dependency @types/jest to v29.2.5
- Update dependency eslint to v8.31.0
- Update renovatebot/github-action action to v34.77.0
- Update dependency @types/sharp to v0.31.1
- Update renovatebot/github-action action to v34.77.1
- Bump get-tsconfig from 4.2.0 to 4.3.0
- Bump aws-sdk from 2.1285.0 to 2.1286.0
- Update dependency glob-promise to v6.0.1
- Update dependency eslint-config-prettier to v8.6.0
- Update typescript-eslint monorepo to v5.48.0
- Update renovatebot/github-action action to v34.78.0
- Update dependency esbuild to v0.16.13
- Bump fastq from 1.14.0 to 1.15.0
- Bump dom-accessibility-api from 0.5.14 to 0.5.15
- Bump json5 from 1.0.1 to 1.0.2
- Bump renovate from 34.76.0 to 34.78.0
- Update dependency patch-package to v6.5.1
- Update renovatebot/github-action action to v34.81.0
- Bump aws-sdk from 2.1286.0 to 2.1287.0
- Bump renovate from 34.78.0 to 34.82.0
- Update renovatebot/github-action action to v34.82.0
- Update dependency aspect_rules_swc to v0.20.2
- Update dependency pulumi_cli to v3.51.0
- Update dependency esbuild to v0.16.14
- Update renovatebot/github-action action to v34.82.2
- Bump lightningcss from 1.17.1 to 1.18.0
- Bump renovate from 34.82.0 to 34.83.1
- Bump axe-core from 4.6.1 to 4.6.2
- Bump es-abstract from 1.20.5 to 1.21.0
- Bump aws-sdk from 2.1287.0 to 2.1288.0
- Bump @pulumi/pulumi from 3.50.2 to 3.51.0
- Update dependency @pulumi/aws to v5.26.0
- Update renovatebot/github-action action to v34.83.1
- Update actions/checkout action to v3.3.0
- Update renovatebot/github-action action to v34.84.1
- Update renovatebot/github-action action to v34.84.2
- Bump is-array-buffer from 3.0.0 to 3.0.1
- Bump es-set-tostringtag from 2.0.0 to 2.0.1
- Bump renovate from 34.83.1 to 34.84.2
- Bump caniuse-lite from 1.0.30001441 to 1.0.30001442
- Update Rust crate swc_common to 0.29.26
- Update Rust crate swc_atoms to 0.4.33
- Update dependency immutable to v4.2.2
- Update renovatebot/github-action action to v34.87.0
- Update renovatebot/github-action action to v34.90.0
- Update dependency esbuild to v0.16.15
- Update dependency rules_rust to v0.16.1
- basic stuff
- Update dependency commander to v9.5.0
- Update dependency jsdom to v21
- Update renovatebot/github-action action to v34.92.0
- Update renovatebot/github-action action to v34.92.1
- fix some issues and create some more
- yay it works :)
- fix
- automatic fixes
- disable weird eslint rule
- Update renovatebot/github-action action to v34.93.0
- Update Rust crate swc_common to 0.29.27
- Update renovatebot/github-action action to v34.94.0
- Update dependency esbuild to v0.16.16
- Bump aws-sdk from 2.1288.0 to 2.1290.0
- Update actions/cache action to v3.2.3
- Update dependency puppeteer to v19.5.0
- Update typescript-eslint monorepo to v5.48.1
- Update react-router monorepo to v6.6.2
- Bump eslint-plugin-jsx-a11y from 6.6.1 to 6.7.0
- Bump renovate from 34.84.2 to 34.96.0
- Bump node-abi from 3.30.0 to 3.31.0
- Update dependency com_github_bazelbuild_buildtools to v6
- Update dependency @bazel/buildifier to v6
- Update dependency @bazel/buildozer to v6
- Update dependency yamllint to v1.29.0
- Include git commit link in version identifier for next.js
- Update dependency rules_python to v0.16.2
- Bump es-abstract from 1.21.0 to 1.21.1
- Bump renovate from 34.96.0 to 34.97.5
- Update dependency @pulumi/aws to v5.27.0
- Update renovatebot/github-action action to v34.97.5
- Update dependency eslint-plugin-react to v7.32.0
- Update dependency esbuild-css-modules-plugin to v2.7.0
- Update dependency puppeteer to v19.5.1
- Update dependency setuptools to v65.7.0
- Update dependency esbuild to v0.16.17
- Update renovatebot/github-action action to v34.99.2
- Update dependency pulumi_cli to v3.51.1
- Update dependency puppeteer to v19.5.2
- Bump eslint-import-resolver-node from 0.3.6 to 0.3.7
- Bump eslint-import-resolver-typescript from 3.5.2 to 3.5.3
- bump @pulumi/pulumi from 3.51.0 to 3.51.1
- Update renovatebot/github-action action to v34.100.1
- Update nextjs monorepo to v13.1.2
- Bump renovate from 34.97.5 to 34.100.1
- bump resolve.exports from 1.1.0 to 1.1.1
- Bump aws-sdk from 2.1290.0 to 2.1294.0
- bump eslint-plugin-jsx-a11y from 6.7.0 to 6.7.1
- Update Rust crate clap to 4.1.0
- Update renovatebot/github-action action to v34.100.2
- Update dependency commander to v10
- Update Rust crate clap to 4.1.1
- Update dependency esbuild to v0.17.0
- Update renovatebot/github-action action to v34.102.0
- Update renovatebot/github-action action to v34.102.1
- Update dependency bazel_gazelle to v0.29.0
- Update renovatebot/github-action action to v34.102.2
- Update dependency eslint to v8.32.0
- Update renovatebot/github-action action to v34.102.7
- Bump renovate from 34.100.1 to 34.102.8
- Update dependency setuptools to v66
- Update typescript-eslint monorepo to v5.48.2
- Update renovatebot/github-action action to v34.102.8
- Update dependency esbuild to v0.17.1
- Update dependency eslint-plugin-react to v7.32.1
- Update dependency eslint-plugin-simple-import-sort to v9
- Bump eslint-plugin-import from 2.26.0 to 2.27.5
- Bump caniuse-lite from 1.0.30001442 to 1.0.30001445
- Bump aws-sdk from 2.1294.0 to 2.1295.0
- Update renovatebot/github-action action to v34.104.0
- Update dependency esbuild to v0.17.2
- Bump aws-sdk from 2.1295.0 to 2.1296.0
- Bump node-addon-api from 5.0.0 to 5.1.0
- Bump renovate from 34.102.8 to 34.105.3
- Bump es-get-iterator from 1.1.2 to 1.1.3
- Update renovatebot/github-action action to v34.105.3
- Update dependency @types/jest to v29.2.6
- Update dependency esbuild to v0.17.3
- Update react-router monorepo to v6.7.0
- Update dependency pulumi_cli to v3.52.0
- Update dependency @microsoft/api-documenter to v7.19.28
- Update dependency @microsoft/api-extractor to v7.33.8
- Update renovatebot/github-action action to v34.105.5
- Bump @types/react from 18.0.26 to 18.0.27
- Bump aws-sdk from 2.1296.0 to 2.1297.0
- Bump dom-accessibility-api from 0.5.15 to 0.5.16
- Bump renovate from 34.105.3 to 34.105.6
- Update dependency esbuild-css-modules-plugin to v2.7.1
- Update renovatebot/github-action action to v34.105.6
- Just use git refs for next.js versions
- Update dependency pulumi_cli to v3.52.1
- Update renovatebot/github-action action to v34.106.0
- Bump aws-sdk from 2.1297.0 to 2.1298.0
- Update nextjs monorepo to v13.1.3
- Bump renovate from 34.105.6 to 34.106.0
- Update dependency @types/glob to v8.0.1
- Update dependency setuptools to v66.1.0
- Update dependency glob-promise to v6.0.2
- Update dependency setuptools to v66.1.1
- Update nextjs monorepo to v13.1.4
- Update renovatebot/github-action action to v34.108.1
- Update renovatebot/github-action action to v34.108.2
- Update renovatebot/github-action action to v34.108.3
- Update renovatebot/github-action action to v34.108.4
- Update dependency esbuild to v0.17.4
- Update dependency jsdom to v21.1.0
- Update renovatebot/github-action action to v34.108.5
- Remove dependency on coreutils sha256
- allow typescript compilation on arm64
- Bump aws-sdk from 2.1298.0 to 2.1299.0
- Update renovatebot/github-action action to v34.109.1
- Update dependency @pulumi/aws to v5.28.0
- Update dependency puppeteer to v19.6.0
- Update typescript-eslint monorepo to v5.49.0
- Update nextjs monorepo to v13.1.5
- Update dependabot/fetch-metadata action to v1.3.6
- Bump @pulumi/pulumi from 3.51.1 to 3.52.1
- Bump caniuse-lite from 1.0.30001445 to 1.0.30001447
- Bump get-intrinsic from 1.1.3 to 1.2.0
- Bump js-sdsl from 4.1.5 to 4.3.0
- Bump axe-core from 4.6.2 to 4.6.3
- Update dependency io_bazel_rules_go to v0.38.0
- Update jest monorepo to v29.4.0
- Update dependency rules_python to v0.17.0
- Bump jest-util from 29.3.1 to 29.4.0
- Bump aws-sdk from 2.1299.0 to 2.1301.0
- Bump jest-message-util from 29.3.1 to 29.4.0
- Bump jest-diff from 29.3.1 to 29.4.0
- Update dependency pathspec to v0.11.0
- Update dependency @microsoft/api-documenter to v7.20.0
- Update dependency @microsoft/api-extractor to v7.34.0
- Update dependency @types/jest to v29.4.0
- Update dependency pulumi_cli to v3.53.0
- Update dependency pulumi_cli to v3.53.1
- Bump caniuse-lite from 1.0.30001447 to 1.0.30001448
- Bump jest-matcher-utils from 29.3.1 to 29.4.0
- Bump @pulumi/pulumi from 3.52.1 to 3.53.1
- Bump renovate from 34.106.0 to 34.114.0
- Update dependency @microsoft/api-documenter to v7.20.1
- Bump expect from 29.3.1 to 29.4.0
- Update dependency puppeteer to v19.6.1
- Update jest monorepo to v29.4.1
- Update dependency io_bazel_rules_go to v0.38.1
- Update react-router monorepo to v6.8.0
- Update dependency rules_python to v0.17.1
- Update dependency rules_python to v0.17.2
- Bump expect from 29.4.0 to 29.4.1
- Bump aws-sdk from 2.1301.0 to 2.1303.0
- Update dependency rules_python to v0.17.3
- Update dependency bazel_skylib to v1.4.0
- Update dependency esbuild to v0.17.5
- Update dependency rules_rust to v0.17.0
- Update dependency eslint-plugin-simple-import-sort to v10
- Update dependency puppeteer to v19.6.2
- Update nextjs monorepo to v13.1.6
- Update dependency setuptools to v67
- Update dependency eslint to v8.33.0
- Update dependency eslint-plugin-react to v7.32.2
- Update dependency @microsoft/api-documenter to v7.21.0
- Update dependency @microsoft/api-documenter to v7.21.1
- Bump caniuse-lite from 1.0.30001448 to 1.0.30001449
- Update actions/cache action to v3.2.4
- Update dependency @microsoft/api-extractor to v7.34.1
- Update dependency @microsoft/api-documenter to v7.21.2
- Bump prettier from 2.8.1 to 2.8.3
- Incrementing version numbers for the whole monorepo.
- Automatically bump major version on all new releases.
- Lint and other automatic fixes.
- Update dependency @swc/cli to v0.1.60
- Bump synckit from 0.8.4 to 0.8.5
- Bump browserslist from 4.21.4 to 4.21.5
- Bump typescript from 4.9.4 to 4.9.5
- Bump aws-sdk from 2.1303.0 to 2.1305.0
- Bump renovate from 34.114.0 to 34.117.2
- Update typescript-eslint monorepo to v5.50.0
- Update dependency com_github_bazelbuild_buildtools to v6.0.1
- Update dependency @bazel/buildozer to v6.0.1
- manual fixes
- Update dependency @bazel/buildifier to v6.0.1
- fixes
- Bump aws-sdk from 2.1305.0 to 2.1306.0
- Bump renovate from 34.117.2 to 34.118.2
- Bump shell-quote from 1.7.4 to 1.8.0
- Update dependency @microsoft/api-extractor to v7.34.2
- Update dependency @microsoft/api-documenter to v7.21.3
- Update dependency puppeteer to v19.6.3
- Update dependency setuptools to v67.1.0
- Update bump.py
- Bump node-releases from 2.0.8 to 2.0.9
- Bump aws-sdk from 2.1306.0 to 2.1307.0
- Bump caniuse-lite from 1.0.30001449 to 1.0.30001450
- Bump renovate from 34.118.2 to 34.119.5
- Update dependency @swc/cli to v0.1.61
- Bump http-cache-semantics from 4.1.0 to 4.1.1
- Update dependency @pulumi/aws to v5.29.0
- Update dependency immutable to v4.2.3
- Bump renovate from 34.119.5 to 34.120.0
- Simplify and abstract build files.
