### PR TITLE
aspect rules js update

### DIFF
--- a/bzl/deps.bzl
+++ b/bzl/deps.bzl
@@ -220,9 +220,9 @@ exports_files(glob(["**/*"], exclude_directories=0))
 
     http_archive(
         name = "aspect_rules_js",
-        sha256 = "08061ba5e5e7f4b1074538323576dac819f9337a0c7d75aee43afc8ae7cb6e18",
-        strip_prefix = "rules_js-1.26.1",
-        url = "https://github.com/aspect-build/rules_js/releases/download/v1.26.1/rules_js-v1.26.1.tar.gz",
+        sha256 = "d8827db3c34fe47607a0668e86524fd85d5bd74f2bfca93046d07f890b5ad4df",
+        strip_prefix = "rules_js-1.27.0",
+        url = "https://github.com/aspect-build/rules_js/releases/download/v1.27.0/rules_js-v1.27.0.tar.gz",
     )
 
     http_archive(

--- a/js/npm/rules.bzl
+++ b/js/npm/rules.bzl
@@ -103,17 +103,14 @@ def npm_pkg(
         out = name + ".tgz",
     )
 
-    npm.npm_binary(
-        name = name + ".publish",
-        data = [name + "_dir"],
-        args = ["publish", "$(location " + name + "_dir)", "--cache", "$$TMPDIR"],
-    )
-
-    npm.npm_test(
-        name = name + ".publish_test",
-        data = [name + "_dir"],
-        args = ["publish", "$(location " + name + "_dir)", "--dry-run", "--cache", "$$TMPDIR"],
-    )
+    ####
+    # TODO: probably re-do this test.
+    ####
+    # npm.npm_test(
+    #    name = name + ".publish_test",
+    #    data = [name + "_dir"],
+    #    args = ["publish", "$(location " + name + "_dir)", "--dry-run", "--cache", "$$TMPDIR"],
+    #)
 
     pkg_srcs = srcs
     pkg_deps = deps + [pkg_json_name]


### PR DESCRIPTION
- Update dependency aspect_rules_js to v1.27.0
- remove old publication code (which is replaced by aspect_rules_js
