### PR TITLE
Minor refactor of ts/fs/index.ts

### DIFF
--- a/ts/fs/index.ts
+++ b/ts/fs/index.ts
@@ -21,32 +21,34 @@ export function getPath(...d: Pick<fs.Dirent, 'name'>[]) {
 async function* _walk(
 	path: Promise<string> | string
 ): AsyncGenerator<[value: Dirent, ...parents: Dirent[]], void, unknown> {
+	const fakeRoot = {
+		name: await path,
+		isDirectory() {
+			return true;
+		},
+		isFile() {
+			return false;
+		},
+		isBlockDevice() {
+			return false;
+		},
+		isCharacterDevice() {
+			return false;
+		},
+		isSymbolicLink() {
+			throw new Error('possibly.');
+		},
+		isFIFO() {
+			return false;
+		},
+		isSocket() {
+			return false;
+		},
+		path: await path,
+	};
 	yield* iter.asyncWalkPath<Dirent>(
 		// this is a fake root dir to make the code simpler.
-		{
-			name: await path,
-			isDirectory() {
-				return true;
-			},
-			isFile() {
-				return false;
-			},
-			isBlockDevice() {
-				return false;
-			},
-			isCharacterDevice() {
-				return false;
-			},
-			isSymbolicLink() {
-				throw new Error('possibly.');
-			},
-			isFIFO() {
-				return false;
-			},
-			isSocket() {
-				return false;
-			},
-		},
+		fakeRoot,
 		// if the current node is a directory, walk its children.
 		async ([v, ...parents]) =>
 			v.isDirectory()


### PR DESCRIPTION
This makes the fake root duck typed. The type of the fakeroot was breaking a couple of patch integrations like https://github.com/Zemnmez/monorepo/pull/3143.

I tried a fix in https://github.com/Zemnmez/monorepo/pull/3145, but it seems to have weird effects on the node exection environment, I'm guessing due to a bad lockfile change.
