### PR TITLE
Enable renovate rollback PRs (for if upstream makes a versioning mistake).

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
 	"platformAutomerge": true,
 	"platformCommit": true,
 	"allowScripts": true,
+	"rollbackPrs": true,
 	"recreateClosed": true,
 	"gitIgnoredAuthors": [ "zemnmez+renovate@gmail.com" ],
     "autodiscoverFilter": [ "Zemnmez/monorepo" ],


### PR DESCRIPTION
https://docs.renovatebot.com/configuration-options/#rollbackprs
