### PR TITLE
Use npm run instead of yarn run in .bazel_fix_commands.json.

### DIFF
--- a/.bazel_fix_commands.json
+++ b/.bazel_fix_commands.json
@@ -1,12 +1,12 @@
 [
   {
     "regex": "potentially fixable with the `--fix` option",
-    "command": "yarn",
+    "command": "npm",
     "args": [ "run", "fix" ]
   },
   {
 	"regex": "(//[^ ]+): no such attribute 'project_deps'",
-	"command": "yarn",
-	"args": [ "buildozer", "move project_deps deps *", "$1" ]
+	"command": "npm",
+	"args": [ "run", "buildozer", "move project_deps deps *", "$1" ]
   }
 ]


### PR DESCRIPTION
Use npm run instead of yarn run in .bazel_fix_commands.json.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Zemnmez/monorepo/pull/3206).
* #3207
* __->__ #3206