### PR TITLE
Remove now vestigial 'autoremove' job from .github/workflows/ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,26 +17,6 @@ on:   # yamllint disable-line rule:truthy
   workflow_dispatch:
 
 jobs:
-  automerge:
-    name: Auto-merge
-    if: github.actor == 'dependabot[bot]' && github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Fetch Dependabot metadata
-        id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1.5.1
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: 'Merge (if dependabot)'
-        run: gh pr merge "$PR_URL" --auto --merge
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
   Test:
     # This runs on both push and PR – for
     # PR, we need to ensure tests pass,

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
 		"@pulumi/command": "4.5.0",
 		"@types/bcryptjs": "2.4.2",
 		"csstype": "^3.1.1",
-		"devtools-protocol": "^0.0.1159816",
+		"devtools-protocol": "^0.0.1158625",
 		"glob-promise": "6.0.3",
 		"json-schema-to-typescript": "^13.0.1",
 		"npm": "^9.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,8 +23,8 @@ dependencies:
     specifier: ^3.1.1
     version: 3.1.1
   devtools-protocol:
-    specifier: ^0.0.1159816
-    version: 0.0.1159816
+    specifier: ^0.0.1158625
+    version: 0.0.1158625
   glob-promise:
     specifier: 6.0.3
     version: 6.0.3(glob@8.1.0)
@@ -8012,8 +8012,8 @@ packages:
     resolution: {integrity: sha512-jEcNGrh6lOXNRJvZb9RjeevtZGrgugPKSMJZxfyxWQnhlKawMPhMtk/dfC+Z/6xNXExlzTKlY5LzIAK/fRpQIw==}
     dev: true
 
-  /devtools-protocol@0.0.1159816:
-    resolution: {integrity: sha512-2cZlHxC5IlgkIWe2pSDmCrDiTzbSJWywjbDDnupOImEBcG31CQgBLV8wWE+5t+C4rimcjHsbzy7CBzf9oFjboA==}
+  /devtools-protocol@0.0.1158625:
+    resolution: {integrity: sha512-WUqOzNAxkW4huh4qk2VUSXFyAHvJEkG+jWYF68/VL285Dct9+a/kQZEWSSdOSdJWktm2yeKW7CRZehdrw19k+g==}
     dev: false
 
   /dezalgo@1.0.4:


### PR DESCRIPTION
Remove now vestigial 'autoremove' job from .github/workflows/ci.yml

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Zemnmez/monorepo/pull/3338).
* __->__ #3338
* #3339