### PR TITLE
eslint_test to depend directly on //:tsconfig (it won't run without it anyway!)

### DIFF
--- a/js/eslint/rules.bzl
+++ b/js/eslint/rules.bzl
@@ -4,6 +4,8 @@ load("//bzl/run_in_workspace:rules.bzl", "run_in_workspace")
 def eslint_test(name = None, data = [], srcs = [], args = [], tags = [], **kwargs):
     args = args + ["--ignore-path", "$(location //:gitignore)"]
 
+    data = data + [ "//:tsconfig" ]
+
     args = args + ["$(rootpath " + x + ")" for x in data + srcs]
     _eslint_test(
         name = name,

--- a/ts/rules.bzl
+++ b/ts/rules.bzl
@@ -29,7 +29,7 @@ def jest_test(jsdom = None, deps = [], **kwargs):
 def ts_lint(name, srcs = [], data = [], **kwargs):
     eslint_test(
         name = name,
-        data = data + ["//:tsconfig"] + srcs,
+        data = data + srcs,
         **kwargs
     )
 


### PR DESCRIPTION
eslint_test to depend directly on //:tsconfig (it won't run without it anyway!)

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Zemnmez/monorepo/pull/3427).
* #3431
* #3430
* #3429
* #3428
* __->__ #3427