### PR TITLE
Perform presubmit after push so that PRs can pick up the cache artifacts.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,7 @@ jobs:
     if: >
       github.event_name == 'pull_request'
       || github.event_name == 'workflow_dispatch'
+
     # Performs all offline testing.
     needs: Presubmit
     runs-on: ubuntu-latest
@@ -134,7 +135,7 @@ jobs:
             'WORKSPACE.bazel', 'MODULE.bazel') }}
           restore-keys: |
             ${{ runner.os }}-bazel-
-      - name: Presubmit
+      - name: Deploy to Staging
         run: |
          bazel run //ci:presubmit -- --dirty --skip-bazel-tests
         env:
@@ -143,10 +144,9 @@ jobs:
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_SECRET }}
   Submit:
     concurrency: pulumi_production
+    if: github.event_name == 'push'
     # Attempts to submit changes to production.
     runs-on: ubuntu-latest
-    needs: ['Presubmit', 'Staging']
-    if: github.event_name == 'push'
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -179,55 +179,10 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_SECRET }}
-  Rollback:
-    concurrency:
-      group: pulumi_production
-    # Undo submit if a failure occurred.
-    runs-on: ubuntu-latest
-    needs: ['Presubmit', 'Staging', 'Submit']
-    # if i got this right, it should run when Submit fails,
-    # but only when also the other tests passed
-    if: |
-      always() &&
-      contains(needs.Submit.result, 'failure') &&
-      contains(needs.Staging.result, 'success')
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          # rollback to success
-          ref: main
-      - name: Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '16'
-      # example copied from:
-      # https://github.com/actions/cache/blob/04f198bf0b2a39f7230a4304bf07747a0bddf146/examples.md
-      - name: Cache Bazel
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/bazel
-          key: >
-            ${{ runner.os }}-bazel-${{
-            hashFiles('.bazelversion', '.bazelrc', 'WORKSPACE',
-            'WORKSPACE.bazel', 'MODULE.bazel') }}
-          restore-keys: |
-            ${{ runner.os }}-bazel-
-      - name: Rollback
-        run: |
-          bazel run //ci:submit
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_SECRET }}
   Postsubmit:
     runs-on: ubuntu-latest
-    needs: ['Presubmit', 'Submit', 'Staging']
     if: github.event_name == 'push'
+    needs: Submit
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,15 @@ jobs:
     concurrency:
       group: concurrency-ci-${{ github.head_ref }}
       cancel-in-progress: true
+    # github's security settings mean that pull requests
+    # can only pull from the upstream 'main' cache.
+    #
+    # This means we need to run these tests so that
+    # PRs can be sped up by loading their cached results.
     if: >
       github.event_name == 'pull_request'
       || github.event_name == 'workflow_dispatch'
+      || github.event_name == 'push'
     # Performs all offline testing.
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Perform presubmit after push so that PRs can pick up the cache artifacts.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Zemnmez/monorepo/pull/3523).
* __->__ #3523
* #3522