### PR TITLE
Fix production CSP defined in ts/next.js/index.tsx

### DIFF
--- a/ts/next.js/index.tsx
+++ b/ts/next.js/index.tsx
@@ -13,7 +13,7 @@ export function HeaderTags() {
 		...BASE_CSP_RULES,
 		process?.env?.NODE_ENV === 'development'
 			? "default-src 'self' 'unsafe-inline' 'unsafe-eval'"
-			: "default-src 'self",
+			: "default-src 'self'",
 	];
 	return (
 		<Head>


### PR DESCRIPTION
Fix production CSP defined in ts/next.js/index.tsx

One day this will need proper testing so that we don't just get errors like this in production!
