### PR TITLE
Back out "Roll forward "Implement noIndex for staging builds.""

### DIFF
--- a/ts/pulumi/index.ts
+++ b/ts/pulumi/index.ts
@@ -51,7 +51,6 @@ export class Component extends Pulumi.ComponentResource {
 						zone.dog.pleaseintroducemetoyour.then(z => z.id)
 					),
 					domain: stage('pleaseintroducemetoyour.dog'),
-					noIndex: args.staging,
 				},
 				{ parent: this }
 			);
@@ -61,7 +60,6 @@ export class Component extends Pulumi.ComponentResource {
 			{
 				zoneId: Pulumi.output(zone.me.zemn.then(z => z.id)),
 				domain: stage('zemn.me'),
-				noIndex: args.staging,
 			},
 			{ parent: this }
 		);
@@ -71,7 +69,6 @@ export class Component extends Pulumi.ComponentResource {
 			{
 				zoneId: Pulumi.output(zone.im.shadwell.then(z => z.id)),
 				domain: stage('shadwell.im'),
-				noIndex: args.staging,
 			},
 			{ parent: this }
 		);

--- a/ts/pulumi/lib/website.ts
+++ b/ts/pulumi/lib/website.ts
@@ -70,11 +70,6 @@ export interface Args {
 	 * The 404 document to serve.
 	 */
 	notFound?: string;
-
-	/**
-	 * Prevent search engines from indexing.
-	 */
-	noIndex: boolean;
 }
 
 /**
@@ -220,27 +215,6 @@ export class Website extends pulumi.ComponentResource {
 			{ parent: this }
 		);
 
-		// response headers policy (http headers)
-
-		const responseHeadersPolicy = new aws.cloudfront.ResponseHeadersPolicy(
-			`${name}_response_headers`.replaceAll('.', '-'),
-			{
-				customHeadersConfig: {
-					items: [
-						...(args.noIndex
-							? [
-									{
-										header: 'x-robots-tag',
-										value: 'noindex',
-										override: false,
-									},
-							  ]
-							: []),
-					],
-				},
-			}
-		);
-
 		// create the cloudfront
 
 		const distribution = new aws.cloudfront.Distribution(
@@ -277,7 +251,6 @@ export class Website extends pulumi.ComponentResource {
 					  }
 					: {}),
 				defaultCacheBehavior: {
-					responseHeadersPolicyId: responseHeadersPolicy.id,
 					// i dont think we use most of these but it's probably not
 					// important
 					allowedMethods: [

--- a/ts/pulumi/pleaseintroducemetoyour.dog/index.ts
+++ b/ts/pulumi/pleaseintroducemetoyour.dog/index.ts
@@ -11,11 +11,6 @@ export interface Args {
 	 * The domain to deploy to.
 	 */
 	domain: string;
-
-	/**
-	 * Prevent indexing the content.
-	 */
-	noIndex: boolean;
 }
 
 /**
@@ -36,7 +31,6 @@ export class Component extends Pulumi.ComponentResource {
 				directory: 'ts/pulumi/pleaseintroducemetoyour.dog/out',
 				zoneId: args.zoneId,
 				domain: args.domain,
-				noIndex: args.noIndex,
 			},
 			{ parent: this }
 		);

--- a/ts/pulumi/shadwell.im/index.ts
+++ b/ts/pulumi/shadwell.im/index.ts
@@ -4,7 +4,6 @@ import Website from 'ts/pulumi/lib/website';
 export interface Args {
 	zoneId: Pulumi.Input<string>;
 	domain: string;
-	noIndex: boolean;
 }
 
 /**
@@ -26,7 +25,6 @@ export class Component extends Pulumi.ComponentResource {
 				directory: 'ts/pulumi/shadwell.im/thomas/',
 				zoneId: args.zoneId,
 				domain: ['thomas', args.domain].join('.'),
-				noIndex: args.noIndex,
 			},
 			{ parent: this }
 		);

--- a/ts/pulumi/zemn.me/index.ts
+++ b/ts/pulumi/zemn.me/index.ts
@@ -4,7 +4,6 @@ import Website from 'ts/pulumi/lib/website';
 export interface Args {
 	zoneId: Pulumi.Input<string>;
 	domain: string;
-	noIndex: boolean;
 }
 
 export class Component extends Pulumi.ComponentResource {
@@ -27,8 +26,6 @@ export class Component extends Pulumi.ComponentResource {
 				// what's already there until it's ready; so this will double stage
 				// to staging.staging.zemn.me.
 				domain: ['staging', args.domain].join('.'),
-				// since this is itself a staging site
-				noIndex: true, // args.noIndex,
 			},
 			{ parent: this }
 		);


### PR DESCRIPTION
Back out "Roll forward "Implement noIndex for staging builds.""

Need to set some basic headers in the base config so that they work on production as well as staging.

```
    	* creating CloudFront Response Headers Policy (monorepo_shadwell-im_thomas_shadwell_im_website_response_headers-e78b2ae): InvalidArgument: The parameter Response Headers Config  requires atleast one of CORS, Security Headers, Remove Headers, Server Timing Headers or Custom Headers.
```

Original commit changeset: 9e1401cde9e4

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Zemnmez/monorepo/pull/3544).
* #3333
* #3332
* #3301
* #3300
* #3298
* #3297
* #3547
* #3545
* __->__ #3544