### PR TITLE
Implement noIndex for staging builds and security header policy builds for both production and staging builds.

### DIFF
--- a/ts/pulumi/index.ts
+++ b/ts/pulumi/index.ts
@@ -51,6 +51,7 @@ export class Component extends Pulumi.ComponentResource {
 						zone.dog.pleaseintroducemetoyour.then(z => z.id)
 					),
 					domain: stage('pleaseintroducemetoyour.dog'),
+					noIndex: args.staging,
 				},
 				{ parent: this }
 			);
@@ -60,6 +61,7 @@ export class Component extends Pulumi.ComponentResource {
 			{
 				zoneId: Pulumi.output(zone.me.zemn.then(z => z.id)),
 				domain: stage('zemn.me'),
+				noIndex: args.staging,
 			},
 			{ parent: this }
 		);
@@ -69,6 +71,7 @@ export class Component extends Pulumi.ComponentResource {
 			{
 				zoneId: Pulumi.output(zone.im.shadwell.then(z => z.id)),
 				domain: stage('shadwell.im'),
+				noIndex: args.staging,
 			},
 			{ parent: this }
 		);

--- a/ts/pulumi/lib/website.ts
+++ b/ts/pulumi/lib/website.ts
@@ -70,6 +70,11 @@ export interface Args {
 	 * The 404 document to serve.
 	 */
 	notFound?: string;
+
+	/**
+	 * Prevent search engines from indexing.
+	 */
+	noIndex: boolean;
 }
 
 /**
@@ -215,6 +220,42 @@ export class Website extends pulumi.ComponentResource {
 			{ parent: this }
 		);
 
+		// response headers policy (http headers)
+
+		const responseHeadersPolicy = new aws.cloudfront.ResponseHeadersPolicy(
+			`${name}_response_headers`.replaceAll('.', '-'),
+			{
+				securityHeadersConfig: {
+					contentTypeOptions: {
+						override: false,
+					},
+					frameOptions: {
+						frameOption: 'DENY',
+						override: false,
+					},
+					strictTransportSecurity: {
+						accessControlMaxAgeSec: 31536000,
+						override: false,
+						includeSubdomains: true,
+						preload: true,
+					},
+				},
+				customHeadersConfig: {
+					items: [
+						...(args.noIndex
+							? [
+									{
+										header: 'x-robots-tag',
+										value: 'noindex',
+										override: false,
+									},
+							  ]
+							: []),
+					],
+				},
+			}
+		);
+
 		// create the cloudfront
 
 		const distribution = new aws.cloudfront.Distribution(
@@ -251,6 +292,7 @@ export class Website extends pulumi.ComponentResource {
 					  }
 					: {}),
 				defaultCacheBehavior: {
+					responseHeadersPolicyId: responseHeadersPolicy.id,
 					// i dont think we use most of these but it's probably not
 					// important
 					allowedMethods: [

--- a/ts/pulumi/pleaseintroducemetoyour.dog/index.ts
+++ b/ts/pulumi/pleaseintroducemetoyour.dog/index.ts
@@ -11,6 +11,11 @@ export interface Args {
 	 * The domain to deploy to.
 	 */
 	domain: string;
+
+	/**
+	 * Prevent indexing the content.
+	 */
+	noIndex: boolean;
 }
 
 /**
@@ -31,6 +36,7 @@ export class Component extends Pulumi.ComponentResource {
 				directory: 'ts/pulumi/pleaseintroducemetoyour.dog/out',
 				zoneId: args.zoneId,
 				domain: args.domain,
+				noIndex: args.noIndex,
 			},
 			{ parent: this }
 		);

--- a/ts/pulumi/shadwell.im/index.ts
+++ b/ts/pulumi/shadwell.im/index.ts
@@ -4,6 +4,7 @@ import Website from 'ts/pulumi/lib/website';
 export interface Args {
 	zoneId: Pulumi.Input<string>;
 	domain: string;
+	noIndex: boolean;
 }
 
 /**
@@ -25,6 +26,7 @@ export class Component extends Pulumi.ComponentResource {
 				directory: 'ts/pulumi/shadwell.im/thomas/',
 				zoneId: args.zoneId,
 				domain: ['thomas', args.domain].join('.'),
+				noIndex: args.noIndex,
 			},
 			{ parent: this }
 		);

--- a/ts/pulumi/zemn.me/index.ts
+++ b/ts/pulumi/zemn.me/index.ts
@@ -4,6 +4,7 @@ import Website from 'ts/pulumi/lib/website';
 export interface Args {
 	zoneId: Pulumi.Input<string>;
 	domain: string;
+	noIndex: boolean;
 }
 
 export class Component extends Pulumi.ComponentResource {
@@ -26,6 +27,8 @@ export class Component extends Pulumi.ComponentResource {
 				// what's already there until it's ready; so this will double stage
 				// to staging.staging.zemn.me.
 				domain: ['staging', args.domain].join('.'),
+				// since this is itself a staging site
+				noIndex: true, // args.noIndex,
 			},
 			{ parent: this }
 		);


### PR DESCRIPTION
Implement noIndex for staging builds and security header policy builds for both production and staging builds.

Back out "Back out "Roll forward "Implement noIndex for staging builds."""

Original commit changeset: b08f969f85609cc7e1dbc8314eef8fbca060ad88

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Zemnmez/monorepo/pull/3545).
* #3333
* #3332
* #3301
* #3300
* #3298
* #3297
* #3547
* __->__ #3545