### PR TITLE
Prevent renovate adding all JSON files as part of automatic fixing.

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,7 +25,7 @@
 					"npx --yes @bazel/bazelisk run //bzl/fix_api:fix_all //..."
 				],
 				"executionMode": "branch",
-				"fileFilters": [ "Cargo.Bazel.lock", "Cargo.toml", "cargo-bazel-lock.json", "**/*.js", "**/*.ts", "**/*.json" ],
+				"fileFilters": [ "Cargo.Bazel.lock", "Cargo.toml", "cargo-bazel-lock.json", "**/*.ts"],
 				"recreateClosed": true
 			}
 		}


### PR DESCRIPTION
Prevent renovate adding all JSON files as part of automatic fixing.

Based on this comment, renovate was adding some very strange files https://github.com/Zemnmez/monorepo/pull/3488#issuecomment-1666254625 -- and as a result, the diff did NOT include an update to pnpm.lock, resulting in the tests passing when, since the lockfile was not updated, the changes did not happen correctly.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Zemnmez/monorepo/pull/3562).
* #3563
* __->__ #3562