### PR TITLE
Fix tests accidentally ephemerally introduced in c466cd3a1697b51b7b7436be2095b26372abf460 and cfb413f7a0eafd6b6cbae2351e

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,11 +154,11 @@ devDependencies:
     specifier: 9.0.2
     version: 9.0.2
   '@typescript-eslint/eslint-plugin':
-    specifier: 5.62.0
-    version: 5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.46.0)(typescript@5.0.4)
+    specifier: 6.2.1
+    version: 6.2.1(@typescript-eslint/parser@6.2.1)(eslint@8.46.0)(typescript@5.0.4)
   '@typescript-eslint/parser':
-    specifier: 5.62.0
-    version: 5.62.0(eslint@8.46.0)(typescript@5.0.4)
+    specifier: 6.2.1
+    version: 6.2.1(eslint@8.46.0)(typescript@5.0.4)
   bcryptjs:
     specifier: 2.4.3
     version: 2.4.3
@@ -205,8 +205,8 @@ devDependencies:
     specifier: 5.0.0
     version: 5.0.0(eslint-config-prettier@8.10.0)(eslint@8.46.0)(prettier@3.0.1)
   eslint-plugin-react:
-    specifier: 7.32.2
-    version: 7.32.2(eslint@8.46.0)
+    specifier: 7.33.1
+    version: 7.33.1(eslint@8.46.0)
   eslint-plugin-simple-import-sort:
     specifier: 10.0.0
     version: 10.0.0(eslint@8.46.0)
@@ -2981,11 +2981,6 @@ packages:
     dependencies:
       eslint: 8.46.0
       eslint-visitor-keys: 3.4.2
-
-  /@eslint-community/regexpp@4.5.1:
-    resolution: {integrity: sha512-Z5ba73P98O1KUYCCJTUeVpja9RcGoMdncZ6T49FCUl2lN38JtCJ+3WgIDBv0AuY4WChU5PmtJmOCTlN6FZTFKQ==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-    dev: true
 
   /@eslint-community/regexpp@4.6.2:
     resolution: {integrity: sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==}
@@ -5939,29 +5934,31 @@ packages:
     dev: true
     optional: true
 
-  /@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0)(eslint@8.46.0)(typescript@5.0.4):
-    resolution: {integrity: sha512-TiZzBSJja/LbhNPvk6yc0JrX9XqhQ0hdh6M2svYfsHGejaKFIAGd9MQ+ERIMzLGlN/kZoYIgdxFV0PuljTKXag==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/eslint-plugin@6.2.1(@typescript-eslint/parser@6.2.1)(eslint@8.46.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-iZVM/ALid9kO0+I81pnp1xmYiFyqibAHzrqX4q5YvvVEyJqY+e6rfTXSCsc2jUxGNqJqTfFSSij/NFkZBiBzLw==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^5.0.0
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      '@typescript-eslint/parser': ^6.0.0 || ^6.0.0-alpha
+      eslint: ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@eslint-community/regexpp': 4.5.1
-      '@typescript-eslint/parser': 5.62.0(eslint@8.46.0)(typescript@5.0.4)
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/type-utils': 5.62.0(eslint@8.46.0)(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.46.0)(typescript@5.0.4)
+      '@eslint-community/regexpp': 4.6.2
+      '@typescript-eslint/parser': 6.2.1(eslint@8.46.0)(typescript@5.0.4)
+      '@typescript-eslint/scope-manager': 6.2.1
+      '@typescript-eslint/type-utils': 6.2.1(eslint@8.46.0)(typescript@5.0.4)
+      '@typescript-eslint/utils': 6.2.1(eslint@8.46.0)(typescript@5.0.4)
+      '@typescript-eslint/visitor-keys': 6.2.1
       debug: 4.3.4
       eslint: 8.46.0
       graphemer: 1.4.0
       ignore: 5.2.4
+      natural-compare: 1.4.0
       natural-compare-lite: 1.4.0
       semver: 7.5.4
-      tsutils: 3.21.0(typescript@5.0.4)
+      ts-api-utils: 1.0.1(typescript@5.0.4)
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
@@ -5987,6 +5984,27 @@ packages:
       - supports-color
     dev: true
 
+  /@typescript-eslint/parser@6.2.1(eslint@8.46.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-Ld+uL1kYFU8e6btqBFpsHkwQ35rw30IWpdQxgOqOh4NfxSDH6uCkah1ks8R/RgQqI5hHPXMaLy9fbFseIe+dIg==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/scope-manager': 6.2.1
+      '@typescript-eslint/types': 6.2.1
+      '@typescript-eslint/typescript-estree': 6.2.1(typescript@5.0.4)
+      '@typescript-eslint/visitor-keys': 6.2.1
+      debug: 4.3.4
+      eslint: 8.46.0
+      typescript: 5.0.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@typescript-eslint/scope-manager@5.62.0:
     resolution: {integrity: sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -5995,21 +6013,29 @@ packages:
       '@typescript-eslint/visitor-keys': 5.62.0
     dev: true
 
-  /@typescript-eslint/type-utils@5.62.0(eslint@8.46.0)(typescript@5.0.4):
-    resolution: {integrity: sha512-xsSQreu+VnfbqQpW5vnCJdq1Z3Q0U31qiWmRhr98ONQmcp/yhiPJFPq8MXiJVLiksmOKSjIldZzkebzHuCGzew==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/scope-manager@6.2.1:
+    resolution: {integrity: sha512-UCqBF9WFqv64xNsIEPfBtenbfodPXsJ3nPAr55mGPkQIkiQvgoWNo+astj9ZUfJfVKiYgAZDMnM6dIpsxUMp3Q==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.2.1
+      '@typescript-eslint/visitor-keys': 6.2.1
+    dev: true
+
+  /@typescript-eslint/type-utils@6.2.1(eslint@8.46.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-fTfCgomBMIgu2Dh2Or3gMYgoNAnQm3RLtRp+jP7A8fY+LJ2+9PNpi5p6QB5C4RSP+U3cjI0vDlI3mspAkpPVbQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
-      eslint: '*'
+      eslint: ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.4)
-      '@typescript-eslint/utils': 5.62.0(eslint@8.46.0)(typescript@5.0.4)
+      '@typescript-eslint/typescript-estree': 6.2.1(typescript@5.0.4)
+      '@typescript-eslint/utils': 6.2.1(eslint@8.46.0)(typescript@5.0.4)
       debug: 4.3.4
       eslint: 8.46.0
-      tsutils: 3.21.0(typescript@5.0.4)
+      ts-api-utils: 1.0.1(typescript@5.0.4)
       typescript: 5.0.4
     transitivePeerDependencies:
       - supports-color
@@ -6018,6 +6044,11 @@ packages:
   /@typescript-eslint/types@5.62.0:
     resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    dev: true
+
+  /@typescript-eslint/types@6.2.1:
+    resolution: {integrity: sha512-528bGcoelrpw+sETlyM91k51Arl2ajbNT9L4JwoXE2dvRe1yd8Q64E4OL7vHYw31mlnVsf+BeeLyAZUEQtqahQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     dev: true
 
   /@typescript-eslint/typescript-estree@5.62.0(typescript@5.0.4):
@@ -6041,20 +6072,40 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.62.0(eslint@8.46.0)(typescript@5.0.4):
-    resolution: {integrity: sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+  /@typescript-eslint/typescript-estree@6.2.1(typescript@5.0.4):
+    resolution: {integrity: sha512-G+UJeQx9AKBHRQBpmvr8T/3K5bJa485eu+4tQBxFq0KoT22+jJyzo1B50JDT9QdC1DEmWQfdKsa8ybiNWYsi0Q==}
+    engines: {node: ^16.0.0 || >=18.0.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@typescript-eslint/types': 6.2.1
+      '@typescript-eslint/visitor-keys': 6.2.1
+      debug: 4.3.4
+      globby: 11.1.0
+      is-glob: 4.0.3
+      semver: 7.5.4
+      ts-api-utils: 1.0.1(typescript@5.0.4)
+      typescript: 5.0.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@typescript-eslint/utils@6.2.1(eslint@8.46.0)(typescript@5.0.4):
+    resolution: {integrity: sha512-eBIXQeupYmxVB6S7x+B9SdBeB6qIdXKjgQBge2J+Ouv8h9Cxm5dHf/gfAZA6dkMaag+03HdbVInuXMmqFB/lKQ==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    peerDependencies:
+      eslint: ^7.0.0 || ^8.0.0
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.46.0)
       '@types/json-schema': 7.0.12
       '@types/semver': 7.5.0
-      '@typescript-eslint/scope-manager': 5.62.0
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.0.4)
+      '@typescript-eslint/scope-manager': 6.2.1
+      '@typescript-eslint/types': 6.2.1
+      '@typescript-eslint/typescript-estree': 6.2.1(typescript@5.0.4)
       eslint: 8.46.0
-      eslint-scope: 5.1.1
       semver: 7.5.4
     transitivePeerDependencies:
       - supports-color
@@ -6066,7 +6117,15 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.62.0
-      eslint-visitor-keys: 3.4.1
+      eslint-visitor-keys: 3.4.2
+    dev: true
+
+  /@typescript-eslint/visitor-keys@6.2.1:
+    resolution: {integrity: sha512-iTN6w3k2JEZ7cyVdZJTVJx2Lv7t6zFA8DCrJEHD2mwfc16AEvvBWVhbFh34XyG2NORCd0viIgQY1+u7kPI0WpA==}
+    engines: {node: ^16.0.0 || >=18.0.0}
+    dependencies:
+      '@typescript-eslint/types': 6.2.1
+      eslint-visitor-keys: 3.4.2
     dev: true
 
   /@yarnpkg/core@3.5.2(typanion@3.13.0):
@@ -8369,9 +8428,9 @@ packages:
       eslint: 8.46.0
       eslint-import-resolver-node: 0.3.7
       eslint-import-resolver-typescript: 3.5.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-plugin-import@2.27.5)(eslint@8.46.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.46.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.2.1)(eslint@8.46.0)
       eslint-plugin-jsx-a11y: 6.7.1(eslint@8.46.0)
-      eslint-plugin-react: 7.32.2(eslint@8.46.0)
+      eslint-plugin-react: 7.33.1(eslint@8.46.0)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.46.0)
       typescript: 5.0.4
     transitivePeerDependencies:
@@ -8409,7 +8468,7 @@ packages:
       enhanced-resolve: 5.15.0
       eslint: 8.46.0
       eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.46.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.46.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@6.2.1)(eslint@8.46.0)
       get-tsconfig: 4.6.2
       globby: 13.2.2
       is-core-module: 2.12.1
@@ -8477,7 +8536,36 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.46.0):
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.2.1)(eslint-import-resolver-node@0.3.7)(eslint@8.46.0):
+    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 6.2.1(eslint@8.46.0)(typescript@5.0.4)
+      debug: 3.2.7
+      eslint: 8.46.0
+      eslint-import-resolver-node: 0.3.7
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@6.2.1)(eslint@8.46.0):
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -8487,7 +8575,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.62.0(eslint@8.46.0)(typescript@5.0.4)
+      '@typescript-eslint/parser': 6.2.1(eslint@8.46.0)(typescript@5.0.4)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
@@ -8495,7 +8583,7 @@ packages:
       doctrine: 2.1.0
       eslint: 8.46.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.5)(eslint@8.46.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.2.1)(eslint-import-resolver-node@0.3.7)(eslint@8.46.0)
       has: 1.0.3
       is-core-module: 2.12.1
       is-glob: 4.0.3
@@ -8596,8 +8684,8 @@ packages:
       eslint: 8.46.0
     dev: true
 
-  /eslint-plugin-react@7.32.2(eslint@8.46.0):
-    resolution: {integrity: sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==}
+  /eslint-plugin-react@7.33.1(eslint@8.46.0):
+    resolution: {integrity: sha512-L093k0WAMvr6VhNwReB8VgOq5s2LesZmrpPdKz/kZElQDzqS7G7+DnKoqT+w4JwuiGeAhAvHO0fvy0Eyk4ejDA==}
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
@@ -8628,24 +8716,12 @@ packages:
       eslint: 8.46.0
     dev: true
 
-  /eslint-scope@5.1.1:
-    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
-    engines: {node: '>=8.0.0'}
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 4.3.0
-    dev: true
-
   /eslint-scope@7.2.2:
     resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       esrecurse: 4.3.0
       estraverse: 5.3.0
-
-  /eslint-visitor-keys@3.4.1:
-    resolution: {integrity: sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   /eslint-visitor-keys@3.4.2:
     resolution: {integrity: sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==}
@@ -8702,7 +8778,7 @@ packages:
     dependencies:
       acorn: 8.10.0
       acorn-jsx: 5.3.2(acorn@8.10.0)
-      eslint-visitor-keys: 3.4.1
+      eslint-visitor-keys: 3.4.2
     dev: false
 
   /espree@9.6.1:
@@ -8729,11 +8805,6 @@ packages:
     engines: {node: '>=4.0'}
     dependencies:
       estraverse: 5.3.0
-
-  /estraverse@4.3.0:
-    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
-    engines: {node: '>=4.0'}
-    dev: true
 
   /estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
@@ -16130,6 +16201,15 @@ packages:
   /trough@2.1.0:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
     dev: false
+
+  /ts-api-utils@1.0.1(typescript@5.0.4):
+    resolution: {integrity: sha512-lC/RGlPmwdrIBFTX59wwNzqh7aR2otPNPR/5brHZm/XKFYKsfqxihXUe9pU3JI+3vGkl+vyCoNNnPhJn3aLK1A==}
+    engines: {node: '>=16.13.0'}
+    peerDependencies:
+      typescript: '>=4.2.0'
+    dependencies:
+      typescript: 5.0.4
+    dev: true
 
   /ts-node@10.9.1(@swc/core@1.3.69)(@types/node@20.4.7)(typescript@5.0.4):
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}

--- a/project/cultist/gen/collate_game_core.ts
+++ b/project/cultist/gen/collate_game_core.ts
@@ -11,6 +11,7 @@ export class ParsingFileError extends Error {
 	}
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function mergeShallow(onto: any, source: any): any {
 	for (const [key, value] of Object.entries(source)) {
 		if (value instanceof Array) {
@@ -31,6 +32,7 @@ function mergeShallow(onto: any, source: any): any {
 			onto[key] = {};
 		}
 
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		for (const [key2, value2] of Object.entries(value as any)) {
 			if (key2 in onto) {
 				throw new Error(

--- a/project/cultist/multiplayer/index.tsx
+++ b/project/cultist/multiplayer/index.tsx
@@ -1,5 +1,5 @@
 import Home from 'project/cultist/multiplayer/pages';
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
-ReactDOM.render(<Home />, document.querySelector('main'));
+createRoot(document.querySelector('main')!).render(<Home />);

--- a/project/cultist/react/table.tsx
+++ b/project/cultist/react/table.tsx
@@ -60,11 +60,11 @@ export const Table: React.FC<Readonly<TableProps>> = ({
 };
 
 export interface SlotProps {
-	X: number;
-	Y: number;
-	width: number;
-	height: number;
-	onDrop: (
+	readonly X: number;
+	readonly Y: number;
+	readonly width: number;
+	readonly height: number;
+	readonly onDrop: (
 		X: number,
 		Y: number,
 		event: React.DragEvent<HTMLDivElement>
@@ -100,22 +100,22 @@ export const Slot: React.FC<SlotProps> = ({
 };
 
 export interface BoardProps {
-	state: State.State;
-	minX?: number;
-	minY?: number;
-	maxX?: number;
-	maxY?: number;
-	cardWidth?: number;
-	cardHeight?: number;
-	defaultX?: number;
-	defaultY?: number;
-	snapGridWidth?: number;
-	snapGridHeight?: number;
+	readonly state: State.State;
+	readonly minX?: number;
+	readonly minY?: number;
+	readonly maxX?: number;
+	readonly maxY?: number;
+	readonly cardWidth?: number;
+	readonly cardHeight?: number;
+	readonly defaultX?: number;
+	readonly defaultY?: number;
+	readonly snapGridWidth?: number;
+	readonly snapGridHeight?: number;
 }
 
 export interface BoardProps {
-	state: State.State;
-	onElementMove: (
+	readonly state: State.State;
+	readonly onElementMove: (
 		X: number,
 		Y: number,
 		stateKey: string,
@@ -240,6 +240,7 @@ export const Card: React.FC<Readonly<CardProps>> = ({
 		>
 			{/* needed to inject xmlns, not in types */}
 			<div
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 				{...({ xmlns: 'http://www.w3.org/1999/xhtml' } as any)}
 				draggable="true"
 				onDragStart={onDragStart}

--- a/project/zemn.me/elements/NavBar/NavBar.tsx
+++ b/project/zemn.me/elements/NavBar/NavBar.tsx
@@ -50,6 +50,7 @@ export const Hamburger: React.FC<
 				className={classes(className, style.hamburger)}
 				onMouseLeave={onMouseLeave}
 				onMouseOver={onMouseOver}
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 				ref={menuRef as any}
 				style={springProps}
 				{...props}

--- a/project/zemn.me/next/components/timeline/timeline.tsx
+++ b/project/zemn.me/next/components/timeline/timeline.tsx
@@ -77,7 +77,7 @@ function groupBy<T, Q>(
 	return m;
 }
 
-function Event({ event: e }: { event: Bio.Event }) {
+function Event({ event: e }: { readonly event: Bio.Event }) {
 	return (
 		<div className={style.event}>
 			<a href={e.url?.toString()} lang={lang.get(e.title)}>
@@ -96,8 +96,8 @@ function Month({
 	month,
 	events,
 }: {
-	month: string;
-	events: Iterable<Bio.Event>;
+	readonly month: string;
+	readonly events: Iterable<Bio.Event>;
 }) {
 	return (
 		<div className={style.month}>
@@ -119,8 +119,8 @@ function Year({
 	year,
 	months,
 }: {
-	year: string;
-	months: Immutable.OrderedMap<string, Immutable.List<Bio.Event>>;
+	readonly year: string;
+	readonly months: Immutable.OrderedMap<string, Immutable.List<Bio.Event>>;
 }) {
 	return (
 		<div className={style.year}>

--- a/renovate.json
+++ b/renovate.json
@@ -25,7 +25,7 @@
 					"npx --yes @bazel/bazelisk run //bzl/fix_api:fix_all //..."
 				],
 				"executionMode": "branch",
-				"fileFilters": [ "Cargo.Bazel.lock", "Cargo.toml", "cargo-bazel-lock.json", "**/*.js", "**/*.ts", "**/*.json" ],
+				"fileFilters": [ "Cargo.Bazel.lock", "Cargo.toml", "cargo-bazel-lock.json", "**/*.ts"],
 				"recreateClosed": true
 			}
 		}

--- a/ts/do-sync/doSync.ts
+++ b/ts/do-sync/doSync.ts
@@ -50,6 +50,7 @@ export type AsyncFn<I extends Value[], O extends Value> = (
 	...v: I
 ) => Promise<O>;
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const gen: (input: Value[], fn: AsyncFn<any, any>) => string = (input, fn) => `
 const main = async () => {
     console.log(JSON.stringify({ type: "success", value: await (${fn})(...${JSON.stringify(
@@ -98,6 +99,7 @@ export const doSync: <I extends Value[], O extends Value>(
 		const rsp: Response = JSON.parse(proc.stdout.toString('utf-8'));
 
 		if (rsp.type == 'failure') throw rsp.value;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		return rsp.value as any;
 	};
 

--- a/ts/math/canvas/element.tsx
+++ b/ts/math/canvas/element.tsx
@@ -4,7 +4,7 @@ import * as Homog from 'ts/math/homog';
 import * as Cnv from '.';
 
 export interface CanvasProps {
-	draw: Cnv.Drawable2D;
+	readonly draw: Cnv.Drawable2D;
 }
 
 export const Canvas: React.FC<CanvasProps> = ({ draw }) => {

--- a/ts/math/shape/shape_test.tsx
+++ b/ts/math/shape/shape_test.tsx
@@ -3,21 +3,22 @@
  */
 
 import React from 'react';
-import { unmountComponentAtNode } from 'react-dom';
-import ReactDOM from 'react-dom';
+import { createRoot, Root } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
 import { Canvas } from 'ts/math/canvas/element';
 import * as Shape from 'ts/math/shape';
 
 let container: HTMLDivElement | null = null;
+let root: Root;
 
 beforeEach(() => {
 	container = document.createElement('div');
+	root = createRoot(container!);
 	document.body.appendChild(container);
 });
 
 afterEach(() => {
-	unmountComponentAtNode(container!);
+	root.unmount();
 	container?.remove();
 	container = null;
 });
@@ -25,7 +26,7 @@ afterEach(() => {
 describe('react.Canvas', () => {
 	it('should append an svg element', () => {
 		act(() => {
-			ReactDOM.render(<Canvas draw={new Shape.Square(1)} />, container);
+			root.render(<Canvas draw={new Shape.Square(1)} />);
 		});
 
 		expect(container?.querySelector('svg')).not.toBeUndefined();

--- a/ts/react/article/blurb/blurb_test.tsx
+++ b/ts/react/article/blurb/blurb_test.tsx
@@ -1,26 +1,27 @@
 import React from 'react';
-import { unmountComponentAtNode } from 'react-dom';
-import ReactDOM from 'react-dom';
+import { createRoot, Root } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
 
 import { Article, Blurb, Main } from '.';
 
 let container: HTMLDivElement | null = null;
+let root: Root;
 
 beforeEach(() => {
 	container = document.createElement('div');
+	root = createRoot(container!);
 	document.body.appendChild(container);
 });
 
 afterEach(() => {
-	unmountComponentAtNode(container!);
+	root.unmount();
 	container?.remove();
 	container = null;
 });
 
 it('renders all content in long form', () => {
 	act(() => {
-		ReactDOM.render(
+		root.render(
 			<Article>
 				<Blurb>
 					<div className="blurb">Hello, world!</div>
@@ -28,8 +29,7 @@ it('renders all content in long form', () => {
 				<Main>
 					<div className="main">main content goes here!</div>
 				</Main>
-			</Article>,
-			container
+			</Article>
 		);
 	});
 
@@ -41,7 +41,7 @@ it('renders all content in long form', () => {
 
 it('renders blurb only in short form', () => {
 	act(() => {
-		ReactDOM.render(
+		root.render(
 			<Article short>
 				<Blurb>
 					<div className="blurb">Hello, world!</div>
@@ -49,8 +49,7 @@ it('renders blurb only in short form', () => {
 				<Main>
 					<div className="main">main content goes here!</div>
 				</Main>
-			</Article>,
-			container
+			</Article>
 		);
 	});
 

--- a/ts/react/article/blurb/index.tsx
+++ b/ts/react/article/blurb/index.tsx
@@ -10,8 +10,11 @@ export const RenderModeContext = React.createContext<RenderMode>(
 );
 
 export interface ArticleProps {
-	short?: boolean;
-	children?: React.ReactElement<unknown, typeof Article | typeof Blurb>[];
+	readonly short?: boolean;
+	readonly children?: React.ReactElement<
+		unknown,
+		typeof Article | typeof Blurb
+	>[];
 }
 
 export const Article: React.FC<ArticleProps> = ({ short, children }) => (
@@ -22,11 +25,11 @@ export const Article: React.FC<ArticleProps> = ({ short, children }) => (
 	</RenderModeContext.Provider>
 );
 
-export const Blurb: React.FC<{ children?: React.ReactNode }> = ({
+export const Blurb: React.FC<{ readonly children?: React.ReactNode }> = ({
 	children,
 }) => <>{children}</>;
 
-export const Main: React.FC<{ children?: React.ReactNode }> = ({
+export const Main: React.FC<{ readonly children?: React.ReactNode }> = ({
 	children,
 }) => {
 	// don't render if in short mode

--- a/ts/react/article/index.tsx
+++ b/ts/react/article/index.tsx
@@ -15,8 +15,8 @@ export interface Article {
 }
 
 export const Article: React.FC<{
-	short?: boolean;
-	children?: React.ReactNode;
+	readonly short?: boolean;
+	readonly children?: React.ReactNode;
 }> = ({ short, children }) => (
 	<RenderModeContext.Provider
 		value={short ? RenderMode.Short : RenderMode.Long}
@@ -26,7 +26,7 @@ export const Article: React.FC<{
 );
 
 export const Title: React.FC<{
-	children?: React.ReactNode;
+	readonly children?: React.ReactNode;
 }> = ({ children }) => <>{children}</>;
 
 /**

--- a/ts/react/element/link/link_test.tsx
+++ b/ts/react/element/link/link_test.tsx
@@ -1,21 +1,22 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import React from 'react';
-import { unmountComponentAtNode } from 'react-dom';
-import ReactDOM from 'react-dom';
+import { createRoot, Root } from 'react-dom/client';
 import { act } from 'react-dom/test-utils';
 import * as Url from 'ts/url';
 
 import { Link } from '.';
 
 let container: HTMLDivElement | null = null;
+let root: Root;
 
 beforeEach(() => {
 	container = document.createElement('div');
+	root = createRoot(container!);
 	document.body.appendChild(container);
 });
 
 afterEach(() => {
-	unmountComponentAtNode(container!);
+	root.unmount();
 	container?.remove();
 	container = null;
 });
@@ -24,18 +25,18 @@ describe('link', () => {
 	describe('Link', () => {
 		it('should overwrite href at all times', () => {
 			act(() => {
-				ReactDOM.render(
+				root.render(
 					<Link>
 						<a className="target" href="https://badsite.com">
 							hello!
 						</a>
-					</Link>,
-					container
+					</Link>
 				);
 			});
 
 			const anchor: HTMLAnchorElement = container?.querySelector(
 				'.target'
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			) as any;
 			expect(anchor).not.toBeUndefined();
 			expect(anchor).toBeInstanceOf(HTMLAnchorElement);
@@ -43,16 +44,16 @@ describe('link', () => {
 		});
 		it('should render a link', () => {
 			act(() => {
-				ReactDOM.render(
+				root.render(
 					<Link href={Url.URL.New`https://google.com`}>
 						<a className="target">hello!</a>
-					</Link>,
-					container
+					</Link>
 				);
 			});
 
 			const anchor: HTMLAnchorElement = container?.querySelector(
 				'.target'
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			) as any;
 			expect(anchor).not.toBeUndefined();
 			expect(anchor).toBeInstanceOf(HTMLAnchorElement);

--- a/ts/react/lang/index.tsx
+++ b/ts/react/lang/index.tsx
@@ -71,7 +71,7 @@ export function useLocale() {
 }
 
 export const LocaleProvider: React.FC<{
-	children?: React.ReactNode;
+	readonly children?: React.ReactNode;
 }> = ({ children }) => {
 	const languages = useLocale();
 	return <locale.Provider value={languages}>{children}</locale.Provider>;

--- a/ts/url/index.ts
+++ b/ts/url/index.ts
@@ -2,6 +2,7 @@ const isSafeUrl = Symbol();
 
 const errInvalidProtocol = Symbol('error: invalid protocol');
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface URL extends globalThis.URL {
 	[isSafeUrl]: true;
 }
@@ -33,6 +34,7 @@ export class Local extends Safe implements URL {
 	}
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export class URL extends Safe implements URL {
 	static New(params: TemplateStringsArray) {
 		const [url] = params;


### PR DESCRIPTION
Fix tests accidentally ephemerally introduced in c466cd3a1697b51b7b7436be2095b26372abf460 and cfb413f7a0eafd6b6cbae2351eba227c2d07c592.



Prevent renovate adding all JSON files as part of automatic fixing.

Based on this comment, renovate was adding some very strange files https://github.com/Zemnmez/monorepo/pull/3488#issuecomment-1666254625 -- and as a result, the diff did NOT include an update to pnpm.lock, resulting in the tests passing when, since the lockfile was not updated, the changes did not happen correctly.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Zemnmez/monorepo/pull/3563).
* #3564
* __->__ #3563