### PR TITLE
Amend pnpm_lock_sync_test to fail anytime pnpm is sad (not just if the lockfile is out of date)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -90,16 +90,4 @@ bin.renovate_config_validator_test(
     data = ["renovate.json"],
 )
 
-# This test is necessitated by several times when tooling has
-# updated package.json, but not updated pnpm-lock.yaml.
-sh_test(
-    name = "pnpm_lockfile_sync",
-    data = ["pnpm-lock.yaml", "package.json", ":pnpm"] + glob(["patches/**/*"]),
-    srcs = [ "pnpm_lock_sync_test.sh" ],
-    env = {
-        "PNPM_BINARY": "$(location :pnpm)"
-    }
-)
-
-
 npm_link_all_packages(name = "node_modules")

--- a/pnpm_lock_sync_test.sh
+++ b/pnpm_lock_sync_test.sh
@@ -1,6 +1,0 @@
-#! /usr/bin/env bash
-if $PNPM_BINARY i --frozen-lockfile --lockfile-only | grep -q ERR_PNPM_OUTDATED_LOCKFILE; then
-    exit 1
-fi
-
-exit 0


### PR DESCRIPTION
Amend pnpm_lock_sync_test to fail anytime pnpm is sad (not just if the lockfile is out of date)
Move pnpm test into presubmit (it breaks out of the sandbox)

Amend pnpm lock sync test accounting for upstream fix.

https://github.com/pnpm/pnpm/issues/6913#event-10016924188



Revert all changes to package.json since lockfile test was broken.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Zemnmez/monorepo/pull/3606).
* #3603
* __->__ #3606