### PR TITLE
Back out "Update dependency @microsoft/api-documenter to v7.22.33"

### DIFF
--- a/ci/presubmit.ts
+++ b/ci/presubmit.ts
@@ -51,11 +51,9 @@ const cmd = new Command('presubmit')
 			await new Promise<void>((ok, err) =>
 				child_process
 					.spawn(
-						'bazel',
+						'npx',
 						[
-							'run',
-							'//:pnpm',
-							'--',
+							'pnpm',
 							'i',
 							'--frozen-lockfile',
 							'--lockfile-only',

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"@fortawesome/fontawesome-svg-core": "6.4.2",
 		"@fortawesome/free-solid-svg-icons": "6.4.2",
 		"@fortawesome/react-fontawesome": "0.2.0",
-		"@microsoft/api-documenter": "7.22.33",
+		"@microsoft/api-documenter": "7.22.32",
 		"@microsoft/api-extractor": "7.36.3",
 		"@pulumi/aws": "5.42.0",
 		"@pulumi/awsx": "1.0.4",


### PR DESCRIPTION
Back out "Update dependency @microsoft/api-documenter to v7.22.33"

Original commit changeset: c8a5b32cd752



The local bazel version of pnpm with --frozen-lockfile and --lockfile only is broken because it's out of date :/
