### PR TITLE
Introduce ts/pulumi/lib/redirect.ts, which sets up a CloudFront distribution with a global redirector, and use it to red

### DIFF
--- a/ts/pulumi/aliases/BUILD.bazel
+++ b/ts/pulumi/aliases/BUILD.bazel
@@ -1,0 +1,10 @@
+load("//ts:rules.bzl", "jest_test", "js_binary", "ts_project")
+
+package(default_visibility = ["//ts/pulumi:__subpackages__"])
+
+ts_project(
+    name = "aliases",
+	deps = [
+		"//:node_modules/@pulumi/pulumi"
+	]
+)

--- a/ts/pulumi/aliases/aliases.ts
+++ b/ts/pulumi/aliases/aliases.ts
@@ -1,0 +1,35 @@
+import * as pulumi from '@pulumi/pulumi';
+
+/**
+ * A list of previous mappings we have made in resource names.
+ *
+ * I think URNs are most reasonable here. It seems like names don't actually totally uniquely identify stuff
+ *
+ * Who knew?
+ */
+export const aliases: Record<string, Array<string | pulumi.Alias> | undefined> =
+	{
+		// the below aliases happened because I introduced the 'CloudFront' abstraction
+		'monorepo_pleaseintroducemetoyour.dog_pleaseintroducemetoyour_dog_website_cloudfront_certificate_validating_record':
+			[
+				'urn:pulumi:staging::monorepo-2::ts:pulumi:Component$ts:pulumi:pleaseintroducemetoyour.dog$ts:pulumi:lib:Website$ts:pulumi:lib:Certificate$aws:route53/record:Record::monorepo_pleaseintroducemetoyour.dog_pleaseintroducemetoyour_dog_website_certificate_validating_record',
+			],
+		'staging.zemn.me_cloudfront_certificate_validating_record': [
+			'urn:pulumi:staging::monorepo-2::ts:pulumi:Component$ts:pulumi:shadwell.im$ts:pulumi:lib:Website$ts:pulumi:lib:Certificate$aws:route53/record:Record::staging.zemn.me_certificate_validating_record',
+		],
+		'monorepo_shadwell.im_thomas_shadwell_im_website_cloudfront_certificate_validating_record':
+			[
+				'urn:pulumi:staging::monorepo-2::ts:pulumi:Component$ts:pulumi:shadwell.im$ts:pulumi:lib:Website$ts:pulumi:lib:Certificate$aws:route53/record:Record::monorepo_shadwell.im_thomas_shadwell_im_website_certificate_validating_record',
+			],
+		'staging.zemn.me_cloudfront_cloudfront_distribution': [
+			'urn:pulumi:prod::monorepo-2::ts:pulumi:Component$ts:pulumi:shadwell.im$ts:pulumi:lib:Website$aws:cloudfront/distribution:Distribution::staging.zemn.me_cloudfront_distribution',
+		],
+		'monorepo_shadwell.im_thomas_shadwell_im_website_cloudfront_cloudfront_distribution':
+			[
+				'urn:pulumi:prod::monorepo-2::ts:pulumi:Component$ts:pulumi:shadwell.im$ts:pulumi:lib:Website$aws:cloudfront/distribution:Distribution::monorepo_shadwell.im_thomas_shadwell_im_website_cloudfront_distribution',
+			],
+		'monorepo_pleaseintroducemetoyour.dog_pleaseintroducemetoyour_dog_website_cloudfront_distribution':
+			[
+				'urn:pulumi:prod::monorepo-2::ts:pulumi:Component$ts:pulumi:pleaseintroducemetoyour.dog$ts:pulumi:lib:Website$aws:cloudfront/distribution:Distribution::monorepo_pleaseintroducemetoyour.dog_pleaseintroducemetoyour_dog_website_cloudfront_distribution',
+			],
+	};

--- a/ts/pulumi/aliases/index.ts
+++ b/ts/pulumi/aliases/index.ts
@@ -1,0 +1,7 @@
+/**
+ * @fileoverview This file defines functionality for the purpose
+ * of making Pulumi aware of aliases (resource identifiers that
+ * must be maintained through a refactoring)
+ */
+
+export * from 'ts/pulumi/aliases/aliases';

--- a/ts/pulumi/lib/BUILD.bazel
+++ b/ts/pulumi/lib/BUILD.bazel
@@ -16,5 +16,6 @@ ts_project(
         "//ts",
         "//ts/iter",
         "//ts/next.js",
+		"//ts/pulumi/aliases"
     ],
 )

--- a/ts/pulumi/lib/certificate.ts
+++ b/ts/pulumi/lib/certificate.ts
@@ -1,5 +1,6 @@
 import * as aws from '@pulumi/aws';
 import * as pulumi from '@pulumi/pulumi';
+import { aliases } from 'ts/pulumi/aliases';
 
 const second = 1;
 const minute = 60 * second;
@@ -42,8 +43,10 @@ export class Certificate extends pulumi.ComponentResource {
 			}
 		);
 
+		const validatingRecordName = `${name}_validating_record`;
+
 		const validatingRecord = new aws.route53.Record(
-			`${name}_validating_record`,
+			validatingRecordName,
 			{
 				name: cert.domainValidationOptions[0].resourceRecordName,
 				records: [cert.domainValidationOptions[0].resourceRecordValue],
@@ -55,6 +58,7 @@ export class Certificate extends pulumi.ComponentResource {
 				// records must be unique
 				parent: this,
 				deleteBeforeReplace: true,
+				aliases: aliases[validatingRecordName],
 			}
 		);
 

--- a/ts/pulumi/lib/cloudfront.ts
+++ b/ts/pulumi/lib/cloudfront.ts
@@ -1,0 +1,231 @@
+import * as aws from '@pulumi/aws';
+import * as pulumi from '@pulumi/pulumi';
+import { aliases } from 'ts/pulumi/aliases';
+import Certificate from 'ts/pulumi/lib/certificate';
+
+// where we will fit any dynamic config entries.
+// this is so typescriptm will error if we don't override
+// this property.
+const hole: symbol = Symbol();
+
+const cacheBehaviorDefaultProperties = {
+	responseHeadersPolicyId: hole,
+	// i dont think we use most of these but it's probably not
+	// important
+	allowedMethods: [
+		'DELETE',
+		'GET',
+		'HEAD',
+		'OPTIONS',
+		'PATCH',
+		'POST',
+		'PUT',
+	],
+	cachedMethods: ['GET', 'HEAD'],
+	// i'm fairly sure this is correct, but the docs kinda suck
+	// on which of AWS's many IDs this might be and sapling histgrep
+	// is broken.
+	forwardedValues: {
+		queryString: false,
+		// I'm not using cookies for anything yet.
+		// and to be honest, i prefer localStorage.
+		cookies: {
+			forward: 'none',
+		},
+	},
+	viewerProtocolPolicy: 'redirect-to-https',
+	minTtl: 0,
+	defaultTtl: 3600,
+	maxTtl: 86400,
+};
+
+cacheBehaviorDefaultProperties satisfies Partial<{
+	[k in keyof aws.types.input.cloudfront.DistributionDefaultCacheBehavior]:
+		| aws.types.input.cloudfront.DistributionDefaultCacheBehavior[k]
+		| typeof hole;
+}>;
+
+const baseProperties = {
+	enabled: true,
+	isIpv6Enabled: true,
+	aliases: hole,
+	restrictions: {
+		geoRestriction: {
+			restrictionType: 'none',
+		},
+	},
+	tags: {
+		Environment: 'production',
+	},
+	viewerCertificate: hole,
+	defaultCacheBehavior: cacheBehaviorDefaultProperties,
+};
+
+baseProperties satisfies Omit<
+	Partial<{
+		[k in keyof aws.cloudfront.DistributionArgs]:
+			| aws.cloudfront.DistributionArgs[k]
+			| typeof hole;
+	}>,
+	'defaultCacheBehavior'
+>;
+
+export interface Args {
+	/**
+	 * Zone to create any needed DNS records in.
+	 */
+	zoneId: pulumi.Input<string>;
+
+	/**
+	 * The domain or subdomain itself in which to create the website.
+	 *
+	 * Leave undefined to host at the root of the domain
+	 *
+	 * @example
+	 * "mywebsite.com."
+	 */
+	domain: string;
+
+	/**
+	 * Prevent search engines from indexing.
+	 */
+	noIndex: boolean;
+
+	distributionArgs: Omit<
+		aws.cloudfront.DistributionArgs,
+		keyof typeof baseProperties
+	> & {
+		// not traditionally optional, but we provide a default.
+		defaultCacheBehavior: Omit<
+			aws.types.input.cloudfront.DistributionDefaultCacheBehavior,
+			keyof typeof cacheBehaviorDefaultProperties
+		>;
+	};
+}
+
+/**
+ * Provision a CloudFront instance at a given domain,
+ * including the certificate needed to serve at that domain.
+ *
+ * Also configures some basic housekeeping, like security headers.
+ */
+export class CloudFront extends pulumi.ComponentResource {
+	distribution: aws.cloudfront.Distribution;
+	constructor(
+		name: string,
+		args: Args,
+		opts?: pulumi.ComponentResourceOptions
+	) {
+		super('ts:pulumi:lib:CloudFront', name, args, opts);
+
+		const certificate = new Certificate(
+			`${name}_certificate`,
+			{
+				zoneId: args.zoneId,
+				domain: args.domain,
+			},
+			{ parent: this }
+		);
+
+		// response headers policy (http headers)
+		const responseHeadersPolicy = new aws.cloudfront.ResponseHeadersPolicy(
+			`${name}_response_headers`.replaceAll('.', '-'),
+			{
+				securityHeadersConfig: {
+					contentTypeOptions: {
+						override: false,
+					},
+					frameOptions: {
+						frameOption: 'DENY',
+						override: false,
+					},
+					strictTransportSecurity: {
+						accessControlMaxAgeSec: 31536000,
+						override: false,
+						includeSubdomains: true,
+						preload: true,
+					},
+				},
+				customHeadersConfig: {
+					items: [
+						...(args.noIndex
+							? [
+									{
+										header: 'x-robots-tag',
+										value: 'noindex',
+										override: false,
+									},
+							  ]
+							: []),
+					],
+				},
+			}
+		);
+
+		const cloudfrontDistributionName = `${name}_cloudfront_distribution`;
+		// create the cloudfront
+		this.distribution = new aws.cloudfront.Distribution(
+			cloudfrontDistributionName,
+			{
+				...args.distributionArgs,
+				...baseProperties,
+				// this is the host that the distribution will expect
+				// (other than the default).
+				aliases: [args.domain],
+				// in the future we could maybe take a bunch of these as args, but
+				// we're not overengineering today!
+				// im sorry this bit kinda sucks
+				defaultCacheBehavior: {
+					...cacheBehaviorDefaultProperties,
+					...args.distributionArgs.defaultCacheBehavior,
+					responseHeadersPolicyId: responseHeadersPolicy.id,
+				},
+				viewerCertificate: {
+					// important to use this so that it waits for the cert
+					// to come up
+					acmCertificateArn: certificate.validation.certificateArn,
+					sslSupportMethod: 'sni-only', // idk really what this does
+				},
+			},
+			// delete before replace due to resource contention ->
+			// creating CloudFront Distribution: CNAMEAlreadyExists:
+			// One or more of the CNAMEs you provided are already associated with a different resource.
+			{
+				parent: this,
+				deleteBeforeReplace: true,
+				aliases: aliases[cloudfrontDistributionName],
+			}
+		);
+
+		// create the alias record that allows the distribution to be located
+		// from the DNS record.
+
+		const record = new aws.route53.Record(
+			`${name}_distribution_record`,
+			{
+				zoneId: args.zoneId,
+				name: args.domain,
+				type: 'A',
+				aliases: [
+					{
+						name: this.distribution.domainName,
+						zoneId: this.distribution.hostedZoneId,
+						evaluateTargetHealth: true,
+					},
+				],
+			},
+			// This needs to be deleted before it is replaced, because
+			// the names of these proof records are unique --
+			// if we try to create a new version of this record
+			// first, aws will complain it already exists
+			{ parent: this, deleteBeforeReplace: true }
+		);
+
+		this.registerOutputs({
+			distribution: this.distribution,
+			record,
+		});
+	}
+}
+
+export default CloudFront;

--- a/ts/pulumi/lib/redirect.ts
+++ b/ts/pulumi/lib/redirect.ts
@@ -1,0 +1,95 @@
+import * as aws from '@pulumi/aws';
+import * as pulumi from '@pulumi/pulumi';
+import CloudFront from 'ts/pulumi/lib/cloudfront';
+
+export interface Args {
+	/**
+	 * Zone to create any needed DNS records in.
+	 */
+	zoneId: pulumi.Input<string>;
+
+	to: string;
+
+	/**
+	 * The domain or subdomain itself in which to create the redirector.
+	 *
+	 * Leave undefined to host at the root of the domain
+	 *
+	 * @example
+	 * "mywebsite.com."
+	 */
+	domain: string;
+
+	/**
+	 * Prevent search engines from indexing.
+	 */
+	noIndex: boolean;
+}
+
+/**
+ * 200 redirects a whole domain somewhere.
+ */
+export class Redirect extends pulumi.ComponentResource {
+	constructor(
+		name: string,
+		args: Args,
+		opts?: pulumi.ComponentResourceOptions
+	) {
+		super('ts:pulumi:lib:Redirect', name, args, opts);
+
+		const redirector = new aws.cloudfront.Function(
+			//  creating CloudFront Function (monorepo_zemn.me_availability.zemn.me_function_redirector-b62460d):
+			// MalformedXML: 2 validation errors detected: Value 'monorepo_zemn.me_availability.zemn.me_function_redirector-b62460d'
+			//at 'name' failed to satisfy constraint: Member must satisfy regular expression pattern: ^[a-zA-Z0-9-_]{1,64}$;
+			// Value 'monorepo_zemn.me_availability.zemn.me_function_redirector-b62460d' at 'name' failed to satisfy constraint:
+			// Member must have length less than or equal to 64
+			`${name}_function_redirector`
+				.replace(/[^a-zA-Z0-9-_]/g, '_')
+				.slice(0, 64),
+			{
+				runtime: 'cloudfront-js-1.0',
+				code: function handler() {
+					return {
+						statusCode: 302,
+						statusDescription: 'Found',
+						headers: {
+							location: { value: args.to },
+						},
+					};
+				}.toString(),
+			},
+			{ parent: this }
+		);
+
+		const c = new CloudFront(
+			`${name}_cloudfront`,
+			{
+				zoneId: args.zoneId,
+				domain: args.domain,
+				noIndex: args.noIndex,
+				distributionArgs: {
+					origins: [
+						{
+							domainName: 'example.com', // everything redirects anyway, so this is basically ignored
+							originId: `${name}_default_origin`,
+						},
+					],
+					defaultCacheBehavior: {
+						targetOriginId: `${name}_default_origin`,
+						functionAssociations: [
+							{
+								eventType: 'viewer-request',
+								functionArn: redirector.arn,
+							},
+						],
+					},
+				},
+			},
+			{ parent: this }
+		);
+
+		this.registerOutputs({ c });
+	}
+}
+
+export default Redirect;

--- a/ts/pulumi/lib/website.ts
+++ b/ts/pulumi/lib/website.ts
@@ -5,7 +5,7 @@ import * as aws from '@pulumi/aws';
 import * as pulumi from '@pulumi/pulumi';
 import mime from 'mime';
 import * as guard from 'ts/guard';
-import Certificate from 'ts/pulumi/lib/certificate';
+import CloudFront from 'ts/pulumi/lib/cloudfront';
 
 const bucketSuffix = '-bucket';
 const pulumiRandomChars = 7;
@@ -88,15 +88,6 @@ export class Website extends pulumi.ComponentResource {
 		opts?: pulumi.ComponentResourceOptions
 	) {
 		super('ts:pulumi:lib:Website', name, args, opts);
-
-		const certificate = new Certificate(
-			`${name}_certificate`,
-			{
-				zoneId: args.zoneId,
-				domain: args.domain,
-			},
-			{ parent: this }
-		);
 
 		/**
 		 * The final subdomain that the website can be loaded from on the target domain.
@@ -220,150 +211,54 @@ export class Website extends pulumi.ComponentResource {
 			{ parent: this }
 		);
 
-		// response headers policy (http headers)
-
-		const responseHeadersPolicy = new aws.cloudfront.ResponseHeadersPolicy(
-			`${name}_response_headers`.replaceAll('.', '-'),
-			{
-				securityHeadersConfig: {
-					contentTypeOptions: {
-						override: false,
-					},
-					frameOptions: {
-						frameOption: 'DENY',
-						override: false,
-					},
-					strictTransportSecurity: {
-						accessControlMaxAgeSec: 31536000,
-						override: false,
-						includeSubdomains: true,
-						preload: true,
-					},
-				},
-				customHeadersConfig: {
-					items: [
-						...(args.noIndex
-							? [
-									{
-										header: 'x-robots-tag',
-										value: 'noindex',
-										override: false,
-									},
-							  ]
-							: []),
-					],
-				},
-			}
-		);
-
 		// create the cloudfront
 
-		const distribution = new aws.cloudfront.Distribution(
-			`${name}_cloudfront_distribution`,
+		// create the cloudfront distribution and cert
+		const cloudFront = new CloudFront(
+			`${name}_cloudfront`,
 			{
-				origins: [
-					{
-						s3OriginConfig: {
-							originAccessIdentity:
-								originAccessIdentity.cloudfrontAccessIdentityPath,
+				zoneId: args.zoneId,
+				domain: args.domain,
+				noIndex: args.noIndex,
+				distributionArgs: {
+					origins: [
+						{
+							s3OriginConfig: {
+								originAccessIdentity:
+									originAccessIdentity.cloudfrontAccessIdentityPath,
+							},
+							domainName: bucket.bucketRegionalDomainName,
+							originId: `${name}_cloudfront_distribution`,
 						},
-						domainName: bucket.bucketRegionalDomainName,
-						originId: `${name}_cloudfront_distribution`,
-					},
-				],
-				enabled: true,
-				isIpv6Enabled: true,
-				defaultRootObject: indexDocumentObject.key,
-				// this is the host that the distribution will expect
-				// (other than the default).
-				aliases: [args.domain],
-				// in the future we could maybe take a bunch of these as args, but
-				// we're not overengineering today!
-				// im sorry this bit kinda sucks
-				...(errorDocumentObject !== undefined
-					? {
-							customErrorResponses: [
-								{
-									errorCode: 404,
-									responseCode: 404,
-									responsePagePath: pulumi.interpolate`/${errorDocumentObject.key}`,
-								},
-							],
-					  }
-					: {}),
-				defaultCacheBehavior: {
-					responseHeadersPolicyId: responseHeadersPolicy.id,
-					// i dont think we use most of these but it's probably not
-					// important
-					allowedMethods: [
-						'DELETE',
-						'GET',
-						'HEAD',
-						'OPTIONS',
-						'PATCH',
-						'POST',
-						'PUT',
 					],
-					cachedMethods: ['GET', 'HEAD'],
-					// i'm fairly sure this is correct, but the docs kinda suck
-					// on which of AWS's many IDs this might be and sapling histgrep
-					// is broken.
-					targetOriginId: `${name}_cloudfront_distribution`,
-					forwardedValues: {
-						queryString: false,
-						// I'm not using cookies for anything yet.
-						// and to be honest, i prefer localStorage.
-						cookies: {
-							forward: 'none',
-						},
+
+					defaultCacheBehavior: {
+						targetOriginId: `${name}_cloudfront_distribution`,
 					},
-					viewerProtocolPolicy: 'redirect-to-https',
-					minTtl: 0,
-					defaultTtl: 3600,
-					maxTtl: 86400,
-				},
-				restrictions: {
-					geoRestriction: {
-						restrictionType: 'none',
-					},
-				},
-				tags: {
-					Environment: 'production',
-				},
-				viewerCertificate: {
-					// important to use this so that it waits for the cert
-					// to come up
-					acmCertificateArn: certificate.validation.certificateArn,
-					sslSupportMethod: 'sni-only', // idk really what this does
+
+					defaultRootObject: indexDocumentObject.key,
+
+					// in the future we could maybe take a bunch of these as args, but
+					// we're not overengineering today!
+					// im sorry this bit kinda sucks
+					...(errorDocumentObject !== undefined
+						? {
+								customErrorResponses: [
+									{
+										errorCode: 404,
+										responseCode: 404,
+										responsePagePath: pulumi.interpolate`/${errorDocumentObject.key}`,
+									},
+								],
+						  }
+						: {}),
 				},
 			},
 			{ parent: this }
 		);
 
-		// create the alias record that allows the distribution to be located
-		// from the DNS record.
-
-		const record = new aws.route53.Record(
-			`${name}_distribution_record`,
-			{
-				zoneId: args.zoneId,
-				name: args.domain,
-				type: 'A',
-				aliases: [
-					{
-						name: distribution.domainName,
-						zoneId: distribution.hostedZoneId,
-						evaluateTargetHealth: true,
-					},
-				],
-			},
-			// records must be unique
-			{ parent: this, deleteBeforeReplace: true }
-		);
-
 		this.registerOutputs({
-			distribution,
-			record,
+			cloudFront,
 			bucketPolicy,
 		});
 	}

--- a/ts/pulumi/zemn.me/index.ts
+++ b/ts/pulumi/zemn.me/index.ts
@@ -1,4 +1,5 @@
 import * as Pulumi from '@pulumi/pulumi';
+import Redirect from 'ts/pulumi/lib/redirect';
 import Website from 'ts/pulumi/lib/website';
 
 export interface Args {


### PR DESCRIPTION
Introduce ts/pulumi/lib/redirect.ts, which sets up a CloudFront distribution with a global redirector, and use it to redirect availability.zemn.me.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Zemnmez/monorepo/pull/3636).
* #3638
* __->__ #3636
* #3635