### PR TITLE
Make DNS records delete before replacement because they're unique.

### DIFF
--- a/ts/pulumi/lib/certificate.ts
+++ b/ts/pulumi/lib/certificate.ts
@@ -52,7 +52,9 @@ export class Certificate extends pulumi.ComponentResource {
 				ttl: 1 * minute, // because these really don't need to be cached
 			},
 			{
+				// records must be unique
 				parent: this,
+				deleteBeforeReplace: true,
 			}
 		);
 

--- a/ts/pulumi/lib/website.ts
+++ b/ts/pulumi/lib/website.ts
@@ -357,7 +357,8 @@ export class Website extends pulumi.ComponentResource {
 					},
 				],
 			},
-			{ parent: this }
+			// records must be unique
+			{ parent: this, deleteBeforeReplace: true }
 		);
 
 		this.registerOutputs({


### PR DESCRIPTION
Make DNS records delete before replacement because they're unique.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Zemnmez/monorepo/pull/3645).
* #3638
* #3636
* #3635
* __->__ #3645