### PR TITLE
Set strict-peer-dependencies to true for pnpm.

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 hoist=false
 auto-install-peers=true
+strict-peer-dependencies=true


### PR DESCRIPTION
Set strict-peer-dependencies to true for pnpm.

strict-peer-dependencies is apparently always true for pnpm 7.x and above.

This thread: https://github.com/renovatebot/renovate/discussions/15416#discussioncomment-2678966

states that it could be the cause of the lockfile not updating issues I'm seeing -- but I don't see pnpm actually complaining about
any dependencies even with this enabled.
