### PR TITLE
CloudFront distribution must be deleted before it is replaced since it may be trying to use CNAMEs that are associated w

### DIFF
--- a/ts/pulumi/lib/website.ts
+++ b/ts/pulumi/lib/website.ts
@@ -337,7 +337,8 @@ export class Website extends pulumi.ComponentResource {
 					sslSupportMethod: 'sni-only', // idk really what this does
 				},
 			},
-			{ parent: this }
+			// creating CloudFront Distribution: CNAMEAlreadyExists: One or more of the CNAMEs you provided are already associated with a different resource.
+			{ parent: this, deleteBeforeReplace: true }
 		);
 
 		// create the alias record that allows the distribution to be located


### PR DESCRIPTION
CloudFront distribution must be deleted before it is replaced since it may be trying to use CNAMEs that are associated with other resources:

Diagnostics:

  aws:cloudfront:Distribution (monorepo_shadwell.im_thomas_shadwell_im_website_cloudfront_cloudfront_distribution):

    error: 1 error occurred:

    	* creating CloudFront Distribution: CNAMEAlreadyExists: One or more of the CNAMEs you provided are already associated with a different resource.

    	status code: 409, request id: b8ca173c-a86e-4ec5-88aa-75dabf1b87d6



  aws:cloudfront:Distribution (staging.zemn.me_cloudfront_cloudfront_distribution):

    error: 1 error occurred:

    	* creating CloudFront Distribution: CNAMEAlreadyExists: One or more of the CNAMEs you provided are already associated with a different resource.

    	status code: 409, request id: c0a6cabc-9f6e-4e09-9ff5-d94b3c513273
