### PR TITLE
Deploy main to staging before trying to deploy the candidate branch.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,8 +134,6 @@ jobs:
           docker-images: true
           large-packages: false
           swap-storage: true
-      - name: Checkout code
-        uses: actions/checkout@v3
       # example copied from:
       # https://github.com/actions/cache/blob/04f198bf0b2a39f7230a4304bf07747a0bddf146/examples.md
       - name: Cache Bazel
@@ -149,11 +147,30 @@ jobs:
             'WORKSPACE.bazel', 'MODULE.bazel') }}
           restore-keys: |
             ${{ runner.os }}-bazel-
-      - name: Deploy to Staging
+        # in order to determine if applying this patch would succeed
+        # *on the mainline branch*
+        # we have to set the Pulumi state to be the same.
+      - name: Checkout main branch
+        uses: actions/checkout@v3
+        with:
+          ref: main
+      - name: Pulumi up from origin/main to staging
+        # dirty used here so the state transition is main -> candidate
+        run: |
+            bazel run //ci:presubmit -- --skip-bazel-tests --dirty \
+            --dangerously-skip-pnpm-lockfile-validation --overwrite
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_SECRET }}
+      - name: Switch back to candidate branch
+        uses: actions/checkout@v3
+      - name: Deploy candidate branch to Staging
+        # we can run this dirty since the next run will --overwrite anyway
         run: |
          bazel run //ci:presubmit -- \
          --skip-bazel-tests \
-         --dangerously-skip-pnpm-lockfile-validation --overwrite
+         --dangerously-skip-pnpm-lockfile-validation --dirty
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,7 +55,7 @@ jobs:
           # By default, queries listed here will override
           # any specified in a config file.
           # Prefix the list here with "+" to use these queries
-          #and those in the config file.
+          # and those in the config file.
 
           # Details on CodeQL's query packs refer to:
           # https://docs.github.com/en/code-security/code-scanning/


### PR DESCRIPTION
Deploy main to staging before trying to deploy the candidate branch.

This commit addresses a subtle, and fairly complex problem.

Pulumi does not know when two resources are mutually exclusive (e.g. DNS records in the same zone).

As a result, to correctly handle these cases, it must be made aware that these resources are the same via aliases.

However, a *failure* does not indicate a roll-back to a known good state -- meaning that under these conditions:

1. A mutually exclusive resource is deployed to the staging environment
2. That content is not destroyed
3. Another candidate branch attempts to deploy this mutually exclusive resource again

-- under these conditions, one candidate can fail due to a mistake in a previous test.

In order to thoroughly address this, we:

1. Destroy the Pulumi state after each presubmit to staging.
2. Before the next test, we deploy the origin/main state to the staging environment.

This ensures that the transition in infrastructure being tested is *always* the transition from main branch state to the PR / candidate branch state.

This ensures

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Zemnmez/monorepo/pull/3654).
* #3655
* __->__ #3654