### PR TITLE
Add --overwrite to presubmit (used to do a destroy() before pulumi up().

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,8 +152,8 @@ jobs:
       - name: Deploy to Staging
         run: |
          bazel run //ci:presubmit -- \
-         --dirty --skip-bazel-tests \
-         --dangerously-skip-pnpm-lockfile-validation
+         --skip-bazel-tests \
+         --dangerously-skip-pnpm-lockfile-validation --overwrite
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/ci/presubmit.ts
+++ b/ci/presubmit.ts
@@ -22,6 +22,11 @@ const cmd = new Command('presubmit')
 		false
 	)
 	.option(
+		'--overwrite',
+		`${'Tear down the existing Pulumi state before performing Pulumi up.'}`,
+		false
+	)
+	.option(
 		'--skip-pulumi-deploy',
 		`${
 			'Skip doing the pulumi deploy once bazel testing is completed. ' +
@@ -105,7 +110,10 @@ const cmd = new Command('presubmit')
 
 		// attempt a deploy of pulumi to staging, and tear it down.
 		if (!o.skipPulumiDeploy) {
-			await deploy_to_staging({ doNotTearDown: o.dirty });
+			await deploy_to_staging({
+				overwrite: o.overwrite,
+				doNotTearDown: o.dirty,
+			});
 		}
 	});
 

--- a/ts/pulumi/deploy_to_staging.ts
+++ b/ts/pulumi/deploy_to_staging.ts
@@ -94,6 +94,10 @@ interface Args {
 	 * Don't destroy the infra once it's turned up.
 	 */
 	doNotTearDown: boolean;
+	/**
+	 * Destroy existing state before doing Pulumi up.
+	 */
+	overwrite: boolean;
 }
 
 export async function main(args: Args) {
@@ -111,12 +115,13 @@ export async function main(args: Args) {
 		'refreshing state'
 	);
 
-	const e2 = !args.doNotTearDown
+	const e2 = args.overwrite
 		? await waitForLock(
 				async () => s.then(v => v.destroy(baseConfig)),
-				'destroying old state'
+				'destroy initial state'
 		  )
 		: undefined;
+
 	const e3 = await waitForLock(
 		async () => s.then(v => v.up(baseConfig)),
 		'deploying'


### PR DESCRIPTION
Add --overwrite to presubmit (used to do a destroy() before pulumi up().

This commit includes a change to put the presubmit to pulumi in overwrite mode cause it's in a weird state.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Zemnmez/monorepo/pull/3656).
* #3655
* #3654
* __->__ #3656