### PR TITLE
Use FileAsset with website BucketObject upload -- this should invalidate old objects based on hash.

### DIFF
--- a/ts/pulumi/lib/website.ts
+++ b/ts/pulumi/lib/website.ts
@@ -148,7 +148,7 @@ export class Website extends pulumi.ComponentResource {
 								guard.isNotNull,
 								() => `couldn't get contentType of ${fPath}`
 							)(mime.getType(fPath)),
-							source: fPath,
+							source: new pulumi.asset.FileAsset(fPath),
 							// wait to be allowed to add stuff to this bucket with public
 							// access.
 							//


### PR DESCRIPTION
Use FileAsset with website BucketObject upload -- this should invalidate old objects based on hash.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Zemnmez/monorepo/pull/3661).
* #3662
* __->__ #3661