### PR TITLE
zemn.me: alter timeline code not to prefer breaking where it's not needed.

### DIFF
--- a/project/zemn.me/next/components/timeline/timeline.module.css
+++ b/project/zemn.me/next/components/timeline/timeline.module.css
@@ -2,11 +2,11 @@
     display: grid;
     grid:
         '....... ......... ........ ........... ....... .......... .....' 1em
-        '....... line-left ........ year        ....... line-right .....' 
-        '....... line-left ........ age         ....... line-right .....' 
+        '....... line-left ........ year        ....... line-right .....'
+        '....... line-left ........ age         ....... line-right .....'
         '....... ......... ........ ........... ....... .......... .....' 1em
         '....... content   content  content     content content    .....'
-        / .2em    1fr       1em     min-content 1em  1fr        .2em
+        / .2em    1fr       1em     auto        1em     1fr        .2em
 }
 
 .year::before, .year::after {
@@ -36,7 +36,7 @@
         '........ ....... ....... ....... ......' .2em
         '........ content content content ......'
         '........ ....... ....... ....... ......' .2em
-        /.5em     1fr min-content 1fr  .5em;
+        /.5em     1fr      auto   1fr     .5em;
     width: 30em;
 }
 


### PR DESCRIPTION
zemn.me: alter timeline code not to prefer breaking where it's not needed.

Because the grid area was set to min-content, the browser text wrapping algorithm was eagerly breaking -- and since asian languates do not break between words, the algorithm would put one character of the word on each line when viewing the timeline from, for example, ja-JA locale.
