### PR TITLE
zemn.me: Fix typo "computersecurity" and disambiguate "security program"

### DIFF
--- a/project/zemn.me/next/pages/index.tsx
+++ b/project/zemn.me/next/pages/index.tsx
@@ -61,8 +61,8 @@ export default function Main() {
 					<Prose>
 						<p>
 							I am an internationally recognised expert on
-							computersecurity, with specialisms in web security,
-							security program construction, and automated
+							computer security, with specialisms in web security,
+							security program (SSDLC) construction, and automated
 							security analysis.
 						</p>
 						<p>


### PR DESCRIPTION
zemn.me: Fix typo "computersecurity" and disambiguate "security program"
