### PR TITLE
availability.zemn.me: add a direct link in case Google security checks fail.

### DIFF
--- a/ts/pulumi/zemn.me/availability/pages/index.tsx
+++ b/ts/pulumi/zemn.me/availability/pages/index.tsx
@@ -4,6 +4,9 @@
 
 import Head from 'next/head';
 
+const URL =
+	'https://calendar.google.com/calendar/u/0/embed?src=thomas@shadwell.im&src=thomas@metatheory.gg&src=thomas.shadwell@gmail.com';
+
 export default function HomePage() {
 	return (
 		<>
@@ -15,7 +18,12 @@ export default function HomePage() {
 				<title>Thomas’ Availability</title>
 			</Head>
 			<main>
-				<iframe src="https://calendar.google.com/calendar/u/0/embed?src=thomas@shadwell.im&src=thomas@metatheory.gg&src=thomas.shadwell@gmail.com" />
+				<p>
+					Occasionally, the below frame can have trouble loading due
+					to Google security checks. If that happens, please{' '}
+					<a href={URL}>view on Google calendar</a> directly instead.
+				</p>
+				<iframe src={URL} />
 			</main>
 		</>
 	);


### PR DESCRIPTION
availability.zemn.me: add a direct link in case Google security checks fail.
