### PR TITLE
Pulumi website: don't interpolate a '/' at the beginning of the NotFound page on Cloud Front instances (it was creating 

### DIFF
--- a/project/zemn.me/next/pages/404.module.css
+++ b/project/zemn.me/next/pages/404.module.css
@@ -1,0 +1,9 @@
+.NotFound {
+	width: 100vw;
+	height: 100vh;
+	display: grid;
+}
+
+.NotFound > * {
+	margin: auto;
+}

--- a/project/zemn.me/next/pages/404.tsx
+++ b/project/zemn.me/next/pages/404.tsx
@@ -1,0 +1,9 @@
+import style from 'project/zemn.me/next/pages/404.module.css';
+
+export default function NotFound() {
+	return (
+		<main className={style.NotFound}>
+			<i lang="en-GB">The requested resource was not found.</i>
+		</main>
+	);
+}

--- a/ts/pulumi/lib/website.ts
+++ b/ts/pulumi/lib/website.ts
@@ -282,7 +282,7 @@ export class Website extends pulumi.ComponentResource {
 								{
 									errorCode: 404,
 									responseCode: 404,
-									responsePagePath: pulumi.interpolate`/${errorDocumentObject.key}`,
+									responsePagePath: errorDocumentObject.key,
 								},
 							],
 					  }


### PR DESCRIPTION
Pulumi website: don't interpolate a '/' at the beginning of the NotFound page on Cloud Front instances (it was creating invalid keys).
