### PR TITLE
pulumi website: add s3:ListBucket permission so that 404s don't become 403s.

### DIFF
--- a/ts/pulumi/lib/website.ts
+++ b/ts/pulumi/lib/website.ts
@@ -203,6 +203,14 @@ export class Website extends pulumi.ComponentResource {
 							Statement: [
 								{
 									Effect: 'Allow',
+									Action: ['s3:ListBucket'],
+									Principal: {
+										AWS: oaiArn,
+									},
+									Resource: [bucketArn],
+								},
+								{
+									Effect: 'Allow',
 									Principal: {
 										AWS: oaiArn,
 									}, // Only allow Cloudfront read access.


### PR DESCRIPTION
pulumi website: add s3:ListBucket permission so that 404s don't become 403s.
