### PR TITLE
Back out "Update dependency com_google_protobuf to v24" -- merged even though the tests didn't pass!

### DIFF
--- a/bzl/deps.bzl
+++ b/bzl/deps.bzl
@@ -52,10 +52,10 @@ def fetch_dependencies():
 
     http_archive(
         name = "com_google_protobuf",
-        sha256 = "39b52572da90ad54c883a828cb2ca68e5ac918aa75d36c3e55c9c76b94f0a4f7",
-        strip_prefix = "protobuf-24.2",
+        sha256 = "543395bc2ae58e72f7be674221db08b8f14e3bd7e3a19158f76105b3b61570a0",
+        strip_prefix = "protobuf-3.21.8",
         urls = [
-            "https://github.com/protocolbuffers/protobuf/archive/v24.2.tar.gz",
+            "https://github.com/protocolbuffers/protobuf/archive/v3.21.8.tar.gz",
         ],
     )
 
@@ -88,10 +88,10 @@ def fetch_dependencies():
 
     http_archive(
         name = "com_google_protobuf",
-        sha256 = "39b52572da90ad54c883a828cb2ca68e5ac918aa75d36c3e55c9c76b94f0a4f7",
-        strip_prefix = "protobuf-24.2",
+        sha256 = "9b4ee22c250fe31b16f1a24d61467e40780a3fbb9b91c3b65be2a376ed913a1a",
+        strip_prefix = "protobuf-3.13.0",
         urls = [
-            "https://github.com/protocolbuffers/protobuf/archive/v24.2.tar.gz",
+            "https://github.com/protocolbuffers/protobuf/archive/v3.13.0.tar.gz",
         ],
     )
 


### PR DESCRIPTION
Back out "Update dependency com_google_protobuf to v24" -- merged even though the tests didn't pass!

Original commit changeset: d17e75f2d6ed

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Zemnmez/monorepo/pull/3720).
* #3719
* __->__ #3720