### PR TITLE
All websites silently died because I replaced BucketObject with BucketObject V2. This should fix those issues.

### DIFF
--- a/ts/pulumi/lib/website.ts
+++ b/ts/pulumi/lib/website.ts
@@ -107,13 +107,15 @@ export class Website extends pulumi.ComponentResource {
 			? relative(args.directory, args.notFound)
 			: undefined;
 
-		const bucket = new aws.s3.Bucket(
+		const bucket = new aws.s3.BucketV2(
 			deriveBucketName(name),
 			{
-				website: {
-					indexDocument,
-					errorDocument,
-				},
+				websites: [
+					{
+						indexDocument,
+						errorDocument,
+					},
+				],
 			},
 			{
 				parent: this,


### PR DESCRIPTION
All websites silently died because I replaced BucketObject with BucketObject V2. This should fix those issues.

---
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/Zemnmez/monorepo/pull/3739).
* #3740
* __->__ #3739