### PR TITLE
pulumi website: remove deprecated 'websites' configuration parameter that is technically never used.

### DIFF
--- a/ts/pulumi/lib/website.ts
+++ b/ts/pulumi/lib/website.ts
@@ -102,21 +102,9 @@ export class Website extends pulumi.ComponentResource {
 		 * The final subdomain that the website can be loaded from on the target domain.
 		 */
 
-		const indexDocument = relative(args.directory, args.index);
-		const errorDocument = args.notFound
-			? relative(args.directory, args.notFound)
-			: undefined;
-
 		const bucket = new aws.s3.BucketV2(
 			deriveBucketName(name),
-			{
-				websites: [
-					{
-						indexDocument,
-						errorDocument,
-					},
-				],
-			},
+			{},
 			{
 				parent: this,
 			}


### PR DESCRIPTION
pulumi website: remove deprecated 'websites' configuration parameter that is technically never used.
