### PR TITLE
Enable aspect_rules_js npm_translate_lock update_pnpm_lock

### DIFF
--- a/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
+++ b/.aspect/rules/external_repository_action_cache/npm_translate_lock_LTE4Nzc1MDcwNjU=
@@ -1,0 +1,7 @@
+# @generated
+# Input hashes for repository rule npm_translate_lock(name = "npm", pnpm_lock = "//:pnpm-lock.yaml").
+# This file should be checked into version control along with the pnpm-lock.yaml file.
+.npmrc=-663512671
+pnpm-lock.yaml=-1445450152
+patches/svgo@3.0.2.patch=-887982568
+package.json=-1527085468

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_SECRET }}
+          ASPECT_RULES_JS_FROZEN_PNPM_LOCK: true
       - name: Switch back to candidate branch
         uses: actions/checkout@v3
       - name: Deploy candidate branch to Staging
@@ -175,6 +176,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_SECRET }}
+          ASPECT_RULES_JS_FROZEN_PNPM_LOCK: true
   Submit:
     concurrency: pulumi_production
     if: github.event_name == 'push'
@@ -217,6 +219,7 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_SECRET }}
+          ASPECT_RULES_JS_FROZEN_PNPM_LOCK: true
   Postsubmit:
     runs-on: ubuntu-latest
     if: github.event_name == 'push'
@@ -256,3 +259,4 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_SECRET }}
+          ASPECT_RULES_JS_FROZEN_PNPM_LOCK: true

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -135,6 +135,7 @@ npm_translate_lock(
     patch_args = {"*": ["-p1"]},
     pnpm_lock = "//:pnpm-lock.yaml",
     verify_node_modules_ignored = "//:.bazelignore",
+	update_pnpm_lock = True,
 )
 
 load("@npm//:repositories.bzl", "npm_repositories")


### PR DESCRIPTION
Enable aspect_rules_js npm_translate_lock update_pnpm_lock

This allows aspect_rules_js to manage and update the lockfile itself.

Environment variables are also added so that it's kept in sync in the CI.

See: https://docs.aspect.build/rules/aspect_rules_js/docs/pnpm/#update_pnpm_lock
